### PR TITLE
Andr1976 jt stuff

### DIFF
--- a/DWSIM.Thermodynamics/Base Classes/MichelsenBase.vb
+++ b/DWSIM.Thermodynamics/Base Classes/MichelsenBase.vb
@@ -40,42 +40,69 @@ Namespace PropertyPackages
 
         Public MustOverride Function CalcHelmoltzEnergy(ByVal phasetype As String, ByVal T As Double, ByVal P As Double, ByVal Vz As Array, ByVal VKij As Object, ByVal VTc As Array, ByVal VPc As Array, ByVal Vw As Array, ByVal Aid As Double, Optional ByVal otherargs As Object = Nothing) As Double
 
-        Public Shared Function CalcIsothermalCompressibility(Vx As Double(), P As Double, T As Double, pp As PropertyPackage, ByVal eos As String) As Double
+        Public Shared Function CalcJouleThomsonCoefficient(Vx As Double(), P As Double, T As Double, pp As PropertyPackage, ByVal eos As String, cp As Double, VMM As Double) As Double
 
-            Dim g1, g2, g3, g4, g5, g6, t1, t2, v, a, b, dadT, R As Double, tmp As Double()
-
-            If eos = "SRK" Then
-                t1 = 1
-                t2 = 0
-                tmp = ThermoPlugs.SRK.ReturnParameters(T, P, Vx, pp.RET_VKij, pp.RET_VTC, pp.RET_VPC, pp.RET_VW)
-            Else
-                t1 = 1 + 2 ^ 0.5
-                t2 = 1 - 2 ^ 0.5
-                tmp = ThermoPlugs.PR.ReturnParameters(T, P, Vx, pp.RET_VKij, pp.RET_VTC, pp.RET_VPC, pp.RET_VW)
-            End If
-
-            a = tmp(0)
-            b = tmp(1)
-            v = tmp(2)
-            dadT = tmp(3)
-
-            g1 = 1 / (v - b)
-            g2 = 1 / (v + t1 * b)
-            g3 = 1 / (v + t2 * b)
-            g4 = g2 + g3
-            g5 = dadT
-            g6 = g2 * g3
-
+            Dim g1, v, a, b, dadT, R, dPdV, dPdT As Double, tmp As Double()
             R = 8.314
 
-            Dim d2PdvdT, dPdT, d2Pdv2, dPdv As Double
 
-            d2PdvdT = -R * g1 ^ 2 + g4 * g5 * g6
-            dPdT = R * g1 - g5 * g6
-            d2Pdv2 = 2 * R * T * g1 ^ 3 - 2 * a * g6 * (g2 ^ 2 + g6 + g3 ^ 2)
-            dPdv = -R * T * g1 ^ 2 + a * g4 * g6
+            If eos = "SRK" Then
 
-            Return -1 / dPdv / v
+                tmp = ThermoPlugs.SRK.ReturnParameters(T, P, Vx, pp.RET_VKij, pp.RET_VTC, pp.RET_VPC, pp.RET_VW)
+
+                a = tmp(0)
+                b = tmp(1)
+                v = tmp(2)
+                dadT = tmp(3)
+                g1 = 1 / (v - b)
+                dPdV = -R * T * g1 ^ 2 + a * (2 * v + b) / (v ^ 2 * (v + b) ^ 2)
+                dPdT = R * g1 - 1 / (v * (v + b)) * dadT
+            Else
+                tmp = ThermoPlugs.PR.ReturnParameters(T, P, Vx, pp.RET_VKij, pp.RET_VTC, pp.RET_VPC, pp.RET_VW)
+
+                a = tmp(0)
+                b = tmp(1)
+                v = tmp(2)
+                dadT = tmp(3)
+                g1 = 1 / (v - b)
+                dPdV = -R * T * (g1 ^ 2) + 2 * a * (v + b) / (v ^ 2 + 2 * b * v - b ^ 2) ^ 2
+                dPdT = R * g1 - 1 / ((v ^ 2 + 2 * b * v - b ^ 2)) * dadT
+            End If
+
+
+            Return -1 / (cp * VMM) * (T * dPdT / dPdV + v)
+
+
+        End Function
+
+        Public Shared Function CalcIsothermalCompressibility(Vx As Double(), P As Double, T As Double, pp As PropertyPackage, ByVal eos As String) As Double
+
+            Dim g1, v, a, b, dadT, R, dPdV As Double, tmp As Double()
+            R = 8.314
+
+
+            If eos = "SRK" Then
+                tmp = ThermoPlugs.SRK.ReturnParameters(T, P, Vx, pp.RET_VKij, pp.RET_VTC, pp.RET_VPC, pp.RET_VW)
+
+                a = tmp(0)
+                b = tmp(1)
+                v = tmp(2)
+                dadT = tmp(3)
+                g1 = 1 / (v - b)
+                dPdV = -R * T * g1 ^ 2 + a * (2 * v + b) / (v ^ 2 * (v + b) ^ 2)
+            Else
+                tmp = ThermoPlugs.PR.ReturnParameters(T, P, Vx, pp.RET_VKij, pp.RET_VTC, pp.RET_VPC, pp.RET_VW)
+
+                a = tmp(0)
+                b = tmp(1)
+                v = tmp(2)
+                dadT = tmp(3)
+                g1 = 1 / (v - b)
+                dPdV = -R * T * (g1 ^ 2) + 2 * a * (v + b) / (v ^ 2 + 2 * b * v - b ^ 2) ^ 2
+
+            End If
+
+            Return -1 / dPdV / v
 
         End Function
 

--- a/DWSIM.Thermodynamics/Property Packages/Models/FluidProperties.vb
+++ b/DWSIM.Thermodynamics/Property Packages/Models/FluidProperties.vb
@@ -353,7 +353,7 @@ Namespace PropertyPackages.Auxiliary
             'T em °F
             T = T * 9 / 5 - 459.7
             'Tpc em °F
-            Tpc = T * 9 / 5 - 459.7
+            Tpc = Tpc * 9 / 5 - 459.7
             'Ppc em lbf/in.2
             Ppc = Ppc / 6894.76
             'Cp em J/kg°F

--- a/DWSIM.Thermodynamics/Property Packages/PengRobinson.vb
+++ b/DWSIM.Thermodynamics/Property Packages/PengRobinson.vb
@@ -991,6 +991,72 @@ Namespace PropertyPackages
 
         End Function
 
+        Public Overrides Function CalcIsothermalCompressibility(p As Interfaces.IPhase) As Double
+
+            Dim T, P0 As Double
+            T = CurrentMaterialStream.Phases(0).Properties.temperature.GetValueOrDefault
+            P0 = CurrentMaterialStream.Phases(0).Properties.pressure.GetValueOrDefault
+            Dim beta, v, a, b, sos As Double
+            Dim tmp As Double()
+
+            Select Case p.Name
+                Case "Mixture"
+                    Return 0.0#
+                Case "Vapor"
+                    Return ThermoPlug.CalcIsothermalCompressibility(RET_VMOL(Phase.Vapor), P0, T, Me, "PR")
+                Case "OverallLiquid"
+                    Return 0.0#
+                Case "Liquid1"
+                    Return ThermoPlug.CalcIsothermalCompressibility(RET_VMOL(Phase.Liquid1), P0, T, Me, "PR")
+                Case "Liquid2"
+                    Return ThermoPlug.CalcIsothermalCompressibility(RET_VMOL(Phase.Liquid2), P0, T, Me, "PR")
+                Case "Liquid3"
+                    Return ThermoPlug.CalcIsothermalCompressibility(RET_VMOL(Phase.Liquid3), P0, T, Me, "PR")
+                Case "Aqueous"
+                    Return ThermoPlug.CalcIsothermalCompressibility(RET_VMOL(Phase.Aqueous), P0, T, Me, "PR")
+                Case "Solid"
+                    Return 0.0#
+            End Select
+        End Function
+
+        Public Overrides Function CalcJouleThomsonCoefficient(p As Interfaces.IPhase) As Double
+
+            Dim T, P0, cp As Double
+
+            T = CurrentMaterialStream.Phases(0).Properties.temperature.GetValueOrDefault
+            P0 = CurrentMaterialStream.Phases(0).Properties.pressure.GetValueOrDefault
+
+            Select Case p.Name
+                Case "Mixture"
+                    Return 0.0#
+                Case "Vapor"
+
+                    DW_CalcProp("heatCapacityCp", Phase.Vapor)
+                    cp = p.Properties.heatCapacityCp.GetValueOrDefault
+                    'Return m_pr.JT_PR(AUX_Z(RET_VMOL(Phase.Vapor), T, P0, Phase.Vapor), T, P0, RET_VMOL(Phase.Vapor), Me.RET_VMM(), Me.RET_VZC(), Me.RET_VTC(), Me.RET_VPC(), cp, Me.RET_VW())
+                    Return ThermoPlug.CalcJouleThomsonCoefficient(RET_VMOL(Phase.Vapor), P0, T, Me, "PR", cp, AUX_MMM(Phase.Vapor))
+                Case "OverallLiquid"
+                    Return 0.0#
+                Case "Liquid1"
+                    DW_CalcProp("heatCapacityCp", Phase.Liquid1)
+                    cp = p.Properties.heatCapacityCp.GetValueOrDefault
+                    Return ThermoPlug.CalcJouleThomsonCoefficient(RET_VMOL(Phase.Liquid1), P0, T, Me, "PR", cp, AUX_MMM(Phase.Liquid1))
+                Case "Liquid2"
+                    DW_CalcProp("heatCapacityCp", Phase.Liquid2)
+                    cp = p.Properties.heatCapacityCp.GetValueOrDefault
+                    Return ThermoPlug.CalcJouleThomsonCoefficient(RET_VMOL(Phase.Liquid2), P0, T, Me, "PR", cp, AUX_MMM(Phase.Liquid2))
+                Case "Liquid3"
+                    DW_CalcProp("heatCapacityCp", Phase.Liquid3)
+                    cp = p.Properties.heatCapacityCp.GetValueOrDefault
+                    Return ThermoPlug.CalcJouleThomsonCoefficient(RET_VMOL(Phase.Liquid3), P0, T, Me, "PR", cp, AUX_MMM(Phase.Liquid3))
+                Case "Aqueous"
+                    DW_CalcProp("heatCapacityCp", Phase.Aqueous)
+                    cp = p.Properties.heatCapacityCp.GetValueOrDefault
+                    Return ThermoPlug.CalcJouleThomsonCoefficient(RET_VMOL(Phase.Aqueous), P0, T, Me, "PR", cp, AUX_MMM(Phase.Aqueous))
+                Case "Solid"
+                    Return 0.0#
+            End Select
+        End Function
     End Class
 
 End Namespace

--- a/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
+++ b/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
@@ -846,7 +846,8 @@ Namespace PropertyPackages
 
             IObj?.Close()
 
-            Return (K / rho) ^ 0.5
+            Return (p.Properties.heatCapacityCp / p.Properties.heatCapacityCv * K / rho) ^ 0.5
+
 
         End Function
 

--- a/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
+++ b/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
@@ -627,7 +627,7 @@ Namespace PropertyPackages
             IObj?.Paragraphs.Add("Isothermal compressibility of a given phase is calculated 
                                 following the thermodynamic definition:")
 
-            IObj?.Paragraphs.Add("<m>\beta=-\frac{1}{V}\frac{\partial V}{\partial P}<m>")
+            IObj?.Paragraphs.Add("<m>\beta_T =-\frac{1}{V}\frac{\partial V}{\partial P}<m>")
 
             IObj?.Paragraphs.Add("The above expression is calculated rigorously by the PR and SRK 
                                 equations of state. For the other models, a numerical derivative 
@@ -638,14 +638,14 @@ Namespace PropertyPackages
             IObj?.Paragraphs.Add("The Bulk Modulus of a phase is defined as the inverse of the 
                                 isothermal compressibility:")
 
-            IObj?.Paragraphs.Add("<m>K=\frac{1}{\beta}<m>")
+            IObj?.Paragraphs.Add("<m>K=\frac{1}{\beta_T}<m>")
 
             IObj?.Paragraphs.Add("<h3>Speed of Sound</h3><p>")
 
-            IObj?.Paragraphs.Add("The speed of sound in a given phase is calculated by the 
+            IObj?.Paragraphs.Add("The speed of sound (isentropic) in a given phase is calculated by the 
                                 following equations:")
 
-            IObj?.Paragraphs.Add("<m>c=\sqrt{\frac{K}{\rho}},</m>")
+            IObj?.Paragraphs.Add("<m>c=\sqrt{\frac{C_p}{C_v}\frac{K}{\rho}},</m>")
 
             IObj?.Paragraphs.Add("where:")
 
@@ -654,6 +654,15 @@ Namespace PropertyPackages
             IObj?.Paragraphs.Add("<mi>K</mi> Bulk Modulus (Pa)")
 
             IObj?.Paragraphs.Add("<mi>\rho</mi> Phase Density (kg/m³)")
+
+            IObj?.Paragraphs.Add("<mi>C_p</mi> Constant pressure Heat capacity (kJ/kg K)")
+
+            IObj?.Paragraphs.Add("<mi>C_v</mi> Constant volume Heat capacity (kJ/kg K)")
+
+            IObj?.Paragraphs.Add("The ratio of heat capacities in above equation is equal to the ratio of 
+                                  the isothermal to the isentropic compressibility in order to shift the basis
+                                   from isothermal to isentropic.")
+
 
             IObj?.Paragraphs.Add("<h3>Joule-Thomson Coefficient</h3>")
 
@@ -673,7 +682,7 @@ Namespace PropertyPackages
 
             IObj?.Paragraphs.Add("<m>\mu=(\frac{\partial T}{\partial P})_{H},</m>")
 
-            IObj?.Paragraphs.Add("The JT coefficient is calculated rigorously by the PR and SRK 
+            IObj?.Paragraphs.Add("The JT coefficient is calculated analytically by the PR and SRK 
                                 equations of state, while the Goldzberg correlation is used for 
                                 all other models,")
 


### PR DESCRIPTION
Re-added analytically calcs of isothermal compressibility and speed of sound for PR and SRK ppacks. Corrected speed of sound calc (generic for all) to be isentropic instead of isothermal. Minor fix in JT_Goldzberg (but more may be needed). Small update to the doc strings. 

Sorry, new to Git so branch was created late in edits