### PR TITLE
Andr1976 misc

### DIFF
--- a/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
+++ b/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
@@ -5637,6 +5637,20 @@ redirect2:                      result = Me.FlashBase.Flash_PS(RET_VMOL(Phase.Mi
 
         End Function
 
+        Public Function AUX_PVAPM(ByVal Phase As Phase, ByVal T As Double) As Double
+
+            Dim val As Double = 0
+            Dim subst As Interfaces.ICompound
+
+            For Each subst In Me.CurrentMaterialStream.Phases(Phase).Compounds.Values
+                val += subst.MoleFraction.GetValueOrDefault * Me.AUX_PVAPi(subst.Name, T)
+            Next
+
+            Return val
+
+        End Function
+
+
         Public Function AUX_KIJ(ByVal sub1 As String, ByVal sub2 As String) As Double
 
             Dim Vc1 As Double = Me.CurrentMaterialStream.Phases(0).Compounds(sub1).ConstantProperties.Critical_Volume

--- a/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
+++ b/DWSIM.Thermodynamics/Property Packages/PropertyPackage.vb
@@ -5642,7 +5642,7 @@ redirect2:                      result = Me.FlashBase.Flash_PS(RET_VMOL(Phase.Mi
             Dim val As Double = 0
             Dim subst As Interfaces.ICompound
 
-            For Each subst In Me.CurrentMaterialStream.Phases(Phase).Compounds.Values
+            For Each subst In Me.CurrentMaterialStream.Phases(Me.RET_PHASEID(Phase)).Compounds.Values
                 val += subst.MoleFraction.GetValueOrDefault * Me.AUX_PVAPi(subst.Name, T)
             Next
 

--- a/DWSIM.UI.Desktop.Editors/UnitOperations/General.cs
+++ b/DWSIM.UI.Desktop.Editors/UnitOperations/General.cs
@@ -917,14 +917,17 @@ namespace DWSIM.UI.Desktop.Editors
                         case Valve.CalculationMode.OutletPressure:
                             pos5 = 0;
                             break;
-                        case Valve.CalculationMode.Kv_Liquid:
+                        case Valve.CalculationMode.Kv_General:
                             pos5 = 2;
                             break;
-                        case Valve.CalculationMode.Kv_Gas:
+                        case Valve.CalculationMode.Kv_Steam:
                             pos5 = 3;
                             break;
-                        case Valve.CalculationMode.Kv_Steam:
+                        case Valve.CalculationMode.Kv_Gas:
                             pos5 = 4;
+                            break;
+                        case Valve.CalculationMode.Kv_Liquid:
+                            pos5 = 5;
                             break;
                     }
                     s.CreateAndAddDropDownRow(container, "Calculation Mode", StringResources.valvecalcmode().ToList(), pos5, (DropDown arg3, EventArgs ev) =>
@@ -938,12 +941,9 @@ namespace DWSIM.UI.Desktop.Editors
                                 valve.CalcMode = Valve.CalculationMode.DeltaP;
                                 break;
                             case 2:
-                                valve.CalcMode = Valve.CalculationMode.Kv_Liquid;
+                                valve.CalcMode = Valve.CalculationMode.Kv_General;
                                 break;
                             case 3:
-                                valve.CalcMode = Valve.CalculationMode.Kv_Gas;
-                                break;
-                            case 4:
                                 valve.CalcMode = Valve.CalculationMode.Kv_Steam;
                                 break;
                         }

--- a/DWSIM.UI.Desktop.Editors/UnitOperations/General.cs
+++ b/DWSIM.UI.Desktop.Editors/UnitOperations/General.cs
@@ -918,16 +918,16 @@ namespace DWSIM.UI.Desktop.Editors
                             pos5 = 0;
                             break;
                         case Valve.CalculationMode.Kv_General:
-                            pos5 = 2;
+                            pos5 = 5;
                             break;
                         case Valve.CalculationMode.Kv_Steam:
-                            pos5 = 3;
-                            break;
-                        case Valve.CalculationMode.Kv_Gas:
                             pos5 = 4;
                             break;
+                        case Valve.CalculationMode.Kv_Gas:
+                            pos5 = 3;
+                            break;
                         case Valve.CalculationMode.Kv_Liquid:
-                            pos5 = 5;
+                            pos5 = 2;
                             break;
                     }
                     s.CreateAndAddDropDownRow(container, "Calculation Mode", StringResources.valvecalcmode().ToList(), pos5, (DropDown arg3, EventArgs ev) =>
@@ -941,10 +941,16 @@ namespace DWSIM.UI.Desktop.Editors
                                 valve.CalcMode = Valve.CalculationMode.DeltaP;
                                 break;
                             case 2:
-                                valve.CalcMode = Valve.CalculationMode.Kv_General;
+                                valve.CalcMode = Valve.CalculationMode.Kv_Liquid;
                                 break;
                             case 3:
+                                valve.CalcMode = Valve.CalculationMode.Kv_Gas;
+                                break;
+                            case 4:
                                 valve.CalcMode = Valve.CalculationMode.Kv_Steam;
+                                break;
+                            case 5:
+                                valve.CalcMode = Valve.CalculationMode.Kv_General;
                                 break;
                         }
                     }, () => CallSolverIfNeeded());

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.Designer.vb
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.Designer.vb
@@ -376,7 +376,7 @@ Partial Class EditingForm_Valve
         resources.ApplyResources(Me.cbCalcMode, "cbCalcMode")
         Me.cbCalcMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.cbCalcMode.FormattingEnabled = True
-        Me.cbCalcMode.Items.AddRange(New Object() {resources.GetString("cbCalcMode.Items"), resources.GetString("cbCalcMode.Items1"), resources.GetString("cbCalcMode.Items2"), resources.GetString("cbCalcMode.Items3"), resources.GetString("cbCalcMode.Items4")})
+        Me.cbCalcMode.Items.AddRange(New Object() {resources.GetString("cbCalcMode.Items"), resources.GetString("cbCalcMode.Items1"), resources.GetString("cbCalcMode.Items2"), resources.GetString("cbCalcMode.Items3"), resources.GetString("cbCalcMode.Items4"), resources.GetString("cbCalcMode.Items5")})
         Me.cbCalcMode.Name = "cbCalcMode"
         Me.ToolTip1.SetToolTip(Me.cbCalcMode, resources.GetString("cbCalcMode.ToolTip"))
         Me.ToolTipValues.SetToolTip(Me.cbCalcMode, resources.GetString("cbCalcMode.ToolTip1"))

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.en.resx
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.en.resx
@@ -154,9 +154,6 @@
   <data name="GroupBox5.Text" xml:space="preserve">
     <value>General Info</value>
   </data>
-  <data name="rtbAnnotations.Size" type="System.Drawing.Size, System.Drawing">
-    <value>335, 194</value>
-  </data>
   <data name="GroupBox4.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 480</value>
   </data>
@@ -165,6 +162,15 @@
   </data>
   <data name="GroupBox4.Text" xml:space="preserve">
     <value>Notes</value>
+  </data>
+  <data name="rtbAnnotations.Size" type="System.Drawing.Size, System.Drawing">
+    <value>335, 194</value>
+  </data>
+  <data name="GroupBox3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>341, 60</value>
+  </data>
+  <data name="GroupBox3.Text" xml:space="preserve">
+    <value>Property Package Settings</value>
   </data>
   <data name="btnConfigurePP.Location" type="System.Drawing.Point, System.Drawing">
     <value>314, 26</value>
@@ -183,12 +189,6 @@
   </data>
   <data name="Label9.Text" xml:space="preserve">
     <value>Property Package</value>
-  </data>
-  <data name="GroupBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>341, 60</value>
-  </data>
-  <data name="GroupBox3.Text" xml:space="preserve">
-    <value>Property Package Settings</value>
   </data>
   <data name="btnCalcKv.Location" type="System.Drawing.Point, System.Drawing">
     <value>245, 96</value>
@@ -257,13 +257,16 @@
     <value>Pressure Drop</value>
   </data>
   <data name="cbCalcMode.Items2" xml:space="preserve">
-    <value>Liquid Service Kv (IEC 60534)</value>
+    <value>General Service Kv (IEC 60534)</value>
   </data>
   <data name="cbCalcMode.Items3" xml:space="preserve">
-    <value>Gas Service Kv (IEC 60534)</value>
+    <value>Steam Service Kv </value>
   </data>
   <data name="cbCalcMode.Items4" xml:space="preserve">
-    <value>Steam Service Kv (IEC 60534)</value>
+    <value>Liquid Service Kv (Deprecated)</value>
+  </data>
+  <data name="cbCalcMode.Items5" xml:space="preserve">
+    <value>Gas Service Kv (Deprecated)</value>
   </data>
   <data name="cbCalcMode.Size" type="System.Drawing.Size, System.Drawing">
     <value>188, 21</value>
@@ -279,6 +282,12 @@
   </data>
   <data name="GroupBox2.Text" xml:space="preserve">
     <value>Calculation Parameters</value>
+  </data>
+  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>341, 83</value>
+  </data>
+  <data name="GroupBox1.Text" xml:space="preserve">
+    <value>Connections</value>
   </data>
   <data name="btnCreateAndConnectOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>287, 50</value>
@@ -334,17 +343,8 @@
   <data name="Label19.Text" xml:space="preserve">
     <value>Inlet Stream</value>
   </data>
-  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>341, 83</value>
-  </data>
-  <data name="GroupBox1.Text" xml:space="preserve">
-    <value>Connections</value>
-  </data>
-  <data name="sizingtsmi.Size" type="System.Drawing.Size, System.Drawing">
-    <value>277, 22</value>
-  </data>
-  <data name="sizingtsmi.Text" xml:space="preserve">
-    <value>Pressure Safety Valve Sizing/Evaluation</value>
+  <data name="UtilitiesCtxMenu.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 30</value>
   </data>
   <data name="AddUtilityTSMI.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 26</value>
@@ -352,8 +352,11 @@
   <data name="AddUtilityTSMI.Text" xml:space="preserve">
     <value>Attach Utility</value>
   </data>
-  <data name="UtilitiesCtxMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 30</value>
+  <data name="sizingtsmi.Size" type="System.Drawing.Size, System.Drawing">
+    <value>277, 22</value>
+  </data>
+  <data name="sizingtsmi.Text" xml:space="preserve">
+    <value>Pressure Safety Valve Sizing/Evaluation</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>355, 705</value>

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.en.resx
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.en.resx
@@ -257,16 +257,16 @@
     <value>Pressure Drop</value>
   </data>
   <data name="cbCalcMode.Items2" xml:space="preserve">
-    <value>General Service Kv (IEC 60534)</value>
-  </data>
-  <data name="cbCalcMode.Items3" xml:space="preserve">
-    <value>Steam Service Kv </value>
-  </data>
-  <data name="cbCalcMode.Items4" xml:space="preserve">
     <value>Liquid Service Kv (Deprecated)</value>
   </data>
-  <data name="cbCalcMode.Items5" xml:space="preserve">
+  <data name="cbCalcMode.Items3" xml:space="preserve">
     <value>Gas Service Kv (Deprecated)</value>
+  </data>
+  <data name="cbCalcMode.Items4" xml:space="preserve">
+    <value>Steam Service Kv </value>
+  </data>
+  <data name="cbCalcMode.Items5" xml:space="preserve">
+    <value>General Service Kv (IEC 60534)</value>
   </data>
   <data name="cbCalcMode.Size" type="System.Drawing.Size, System.Drawing">
     <value>188, 21</value>

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.resx
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.resx
@@ -127,8 +127,8 @@
   <data name="&gt;&gt;tbOp.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="Label3.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="btnUtils.ToolTip2" xml:space="preserve">
+    <value>Add/View Utilities</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="chkEnableKvOpRel.TabIndex" type="System.Int32, mscorlib">
@@ -147,23 +147,17 @@
     <value>Label12</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
   <data name="chkEnableKvOpRel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
   </data>
   <data name="&gt;&gt;Label1.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="btnConfigurePP.ToolTip1" xml:space="preserve">
-    <value>Configure</value>
+  <data name="btnDisconnect1.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
   </data>
-  <data name="Label11.ToolTip" xml:space="preserve">
+  <data name="$this.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="&gt;&gt;cbInlet1.Name" xml:space="preserve">
-    <value>cbInlet1</value>
   </data>
   <data name="btnDisconnectOutlet1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -180,20 +174,23 @@
   <data name="&gt;&gt;lblConnectedTo.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tbOutletPressure.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
+  <data name="&gt;&gt;Label11.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;AddUtilityTSMI.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;Label4.ZOrder" xml:space="preserve">
     <value>4</value>
-  </data>
-  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
   </data>
   <data name="Label13.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
   </data>
   <data name="&gt;&gt;btnUtils.Name" xml:space="preserve">
     <value>btnUtils</value>
+  </data>
+  <data name="GroupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 104</value>
   </data>
   <data name="tbKvOpRel.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
@@ -225,8 +222,8 @@
   <data name="&gt;&gt;btnDisconnectOutlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="GroupBox5.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="Label9.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="AddUtilityTSMI.Size" type="System.Drawing.Size, System.Drawing">
     <value>179, 26</value>
@@ -240,11 +237,14 @@
   <data name="&gt;&gt;cbPropPack.Parent" xml:space="preserve">
     <value>GroupBox3</value>
   </data>
+  <data name="Label1.Text" xml:space="preserve">
+    <value>Kv(max) (IEC 60534)</value>
+  </data>
   <data name="Label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="GroupBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="&gt;&gt;cbPress.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Label9.ToolTip1" xml:space="preserve">
     <value />
@@ -258,6 +258,9 @@
   <data name="&gt;&gt;GroupBox4.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="Label12.ToolTip" xml:space="preserve">
+    <value />
+  </data>
   <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
@@ -266,9 +269,6 @@
   </data>
   <data name="GroupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
-  </data>
-  <data name="btnCreateAndConnectInlet1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
   </data>
   <data name="Label13.Text" xml:space="preserve">
     <value>Ligado a</value>
@@ -279,20 +279,32 @@
   <data name="cbPressureDropU.Items" xml:space="preserve">
     <value>Mínima das Entradas</value>
   </data>
+  <data name="&gt;&gt;sizingtsmi.Name" xml:space="preserve">
+    <value>sizingtsmi</value>
+  </data>
+  <data name="GroupBox1.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
   <data name="&gt;&gt;chkActive.Name" xml:space="preserve">
     <value>chkActive</value>
   </data>
   <data name="Label3.Text" xml:space="preserve">
     <value>Queda de Pressão</value>
   </data>
+  <data name="cbCalcMode.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
   <data name="&gt;&gt;GroupBox5.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cbCalcMode.Items4" xml:space="preserve">
-    <value>Kv para Vapor de Água (IEC 60534)</value>
+  <data name="cbCalcMode.Items5" xml:space="preserve">
+    <value>Gas Service Kv</value>
   </data>
-  <data name="cbCalcMode.Items3" xml:space="preserve">
-    <value>Kv para Gases (IEC 60534)</value>
+  <data name="btnCreateAndConnectInlet1.TabIndex" type="System.Int32, mscorlib">
+    <value>45</value>
+  </data>
+  <data name="btnDisconnect1.ToolTip1" xml:space="preserve">
+    <value>Disconnect</value>
   </data>
   <data name="cbCalcMode.Items2" xml:space="preserve">
     <value>Kv para Líquidos (IEC 60534)</value>
@@ -309,11 +321,8 @@
   <data name="btnDisconnectOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>334, 50</value>
   </data>
-  <data name="tbKv.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;Label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="btnDisconnect1.ToolTip" xml:space="preserve">
+    <value>Desconectar</value>
   </data>
   <data name="&gt;&gt;Label5.Parent" xml:space="preserve">
     <value>GroupBox2</value>
@@ -327,11 +336,11 @@
   <data name="Label9.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 13</value>
   </data>
-  <data name="Label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;Label13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="UtilitiesCtxMenu.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="btnDisconnectOutlet1.ToolTip" xml:space="preserve">
+    <value>Desconectar</value>
   </data>
   <data name="tbKvOpRel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -342,11 +351,11 @@
   <data name="lblStatus.Location" type="System.Drawing.Point, System.Drawing">
     <value>132, 47</value>
   </data>
-  <data name="Label10.ToolTip1" xml:space="preserve">
-    <value />
-  </data>
   <data name="&gt;&gt;GroupBox5.Parent" xml:space="preserve">
     <value>$this</value>
+  </data>
+  <data name="GroupBox4.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>EditingForm_Valve</value>
@@ -381,8 +390,17 @@
   <data name="Label5.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;cbPress.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="rtbAnnotations.Size" type="System.Drawing.Size, System.Drawing">
+    <value>355, 171</value>
+  </data>
+  <data name="Label7.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;rtbAnnotations.Type" xml:space="preserve">
+    <value>Extended.Windows.Forms.RichTextBoxExtended, RichTextBoxExtended, Version=2.0.2954.894, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="UtilitiesCtxMenu.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="cbInlet1.ToolTip" xml:space="preserve">
     <value />
@@ -399,8 +417,8 @@
   <data name="&gt;&gt;btnDisconnect1.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="tbKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 20</value>
+  <data name="Label8.Text" xml:space="preserve">
+    <value>Tipo de Cálculo</value>
   </data>
   <data name="&gt;&gt;btnDisconnectOutlet1.Parent" xml:space="preserve">
     <value>GroupBox1</value>
@@ -420,9 +438,6 @@
   <data name="Label4.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 145</value>
   </data>
-  <data name="chkEnableKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 17</value>
-  </data>
   <data name="Label9.Text" xml:space="preserve">
     <value>Pacote de Propriedades</value>
   </data>
@@ -438,11 +453,11 @@
   <data name="tbOp.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 190</value>
   </data>
-  <data name="&gt;&gt;tbOp.Name" xml:space="preserve">
-    <value>tbOp</value>
+  <data name="lblTag.Size" type="System.Drawing.Size, System.Drawing">
+    <value>195, 20</value>
   </data>
-  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+  <data name="GroupBox1.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="tbKv.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
@@ -462,8 +477,8 @@
   <data name="chkActive.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="lblConnectedTo.Text" xml:space="preserve">
-    <value>Objeto</value>
+  <data name="&gt;&gt;GroupBox1.Name" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
   <data name="&gt;&gt;tbOp.ZOrder" xml:space="preserve">
     <value>1</value>
@@ -477,11 +492,14 @@
   <data name="&gt;&gt;cbPressureDropU.Name" xml:space="preserve">
     <value>cbPressureDropU</value>
   </data>
-  <data name="GroupBox5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>361, 98</value>
+  <data name="Label2.ToolTip1" xml:space="preserve">
+    <value />
   </data>
-  <data name="rtbAnnotations.Size" type="System.Drawing.Size, System.Drawing">
-    <value>355, 171</value>
+  <data name="&gt;&gt;chkEnableKvOpRel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cbPressureDropU.Location" type="System.Drawing.Point, System.Drawing">
+    <value>266, 47</value>
   </data>
   <data name="GroupBox5.ToolTip1" xml:space="preserve">
     <value />
@@ -491,9 +509,6 @@
   </data>
   <data name="btnConfigurePP.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Stretch</value>
-  </data>
-  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 13</value>
   </data>
   <data name="&gt;&gt;Label4.Name" xml:space="preserve">
     <value>Label4</value>
@@ -519,29 +534,26 @@
   <data name="&gt;&gt;tbOp.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label8.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
+  <data name="Label8.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;tbKv.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;chkEnableKvOpRel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnUtils.ToolTip1" xml:space="preserve">
-    <value>Add/View Utilities</value>
+  <data name="tbKv.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="tbKv.ToolTip2" xml:space="preserve">
     <value />
+  </data>
+  <data name="btnConfigurePP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 21</value>
   </data>
   <data name="&gt;&gt;btnCreateAndConnectOutlet1.Name" xml:space="preserve">
     <value>btnCreateAndConnectOutlet1</value>
   </data>
   <data name="btnDisconnect1.Size" type="System.Drawing.Size, System.Drawing">
     <value>21, 21</value>
-  </data>
-  <data name="&gt;&gt;chkActive.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="cbPropPack.ToolTip2" xml:space="preserve">
     <value />
@@ -564,17 +576,14 @@
   <data name="&gt;&gt;Label1.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="btnConfigurePP.ToolTip" xml:space="preserve">
-    <value>Configurar</value>
-  </data>
-  <data name="tbOutletPressure.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 72</value>
+  <data name="cbPropPack.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
   </data>
   <data name="&gt;&gt;Label3.Name" xml:space="preserve">
     <value>Label3</value>
   </data>
-  <data name="&gt;&gt;btnDisconnectOutlet1.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="Label10.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
   </data>
   <data name="&gt;&gt;btnCalcKv.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -588,11 +597,17 @@
   <data name="Label10.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 56</value>
   </data>
-  <data name="&gt;&gt;AddUtilityTSMI.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="chkEnableKvOpRel.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
+  <data name="cbPress.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="tbKv.ToolTip" xml:space="preserve">
     <value />
+  </data>
+  <data name="Label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="GroupBox5.ToolTip2" xml:space="preserve">
     <value />
@@ -616,7 +631,7 @@
     <value>Adicionar/Ver Utilidades</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>DWSIM.SharedClasses.ObjectEditorForm, DWSIM.SharedClasses, Version=6.3.7603.33002, Culture=neutral, PublicKeyToken=null</value>
+    <value>DWSIM.SharedClasses.ObjectEditorForm, DWSIM.SharedClasses, Version=6.4.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="lblConnectedTo.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -630,23 +645,26 @@
   <data name="GroupBox2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
+  <data name="lblTag.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
   <data name="&gt;&gt;btnCalcKv.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 74</value>
-  </data>
-  <data name="Label7.ToolTip1" xml:space="preserve">
+  <data name="Label11.ToolTip" xml:space="preserve">
     <value />
   </data>
   <data name="btnConfigureFlashAlg.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
   </data>
+  <data name="UtilitiesCtxMenu.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
   <data name="&gt;&gt;cbCalcMode.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
-    <value>10</value>
+  <data name="btnUtils.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="btnUtils.Size" type="System.Drawing.Size, System.Drawing">
     <value>20, 20</value>
@@ -660,20 +678,17 @@
   <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="&gt;&gt;btnCalcKv.Name" xml:space="preserve">
-    <value>btnCalcKv</value>
-  </data>
   <data name="GroupBox4.Size" type="System.Drawing.Size, System.Drawing">
     <value>361, 190</value>
   </data>
   <data name="Label13.ToolTip1" xml:space="preserve">
     <value />
   </data>
+  <data name="cbCalcMode.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>372, 713</value>
-  </data>
-  <data name="btnCreateAndConnectInlet1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>307, 23</value>
   </data>
   <data name="cbPress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -681,11 +696,14 @@
   <data name="&gt;&gt;Label9.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chkEnableKvOpRel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 122</value>
+  <data name="Label7.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="btnCreateAndConnectInlet1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="Label4.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;tbKv.Parent" xml:space="preserve">
     <value>GroupBox2</value>
@@ -693,17 +711,20 @@
   <data name="tbKv.Size" type="System.Drawing.Size, System.Drawing">
     <value>113, 20</value>
   </data>
+  <data name="GroupBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 189</value>
+  </data>
   <data name="&gt;&gt;btnUtils.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="btnCreateAndConnectOutlet1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
-  </data>
   <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;GroupBox1.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="&gt;&gt;GroupBox2.Name" xml:space="preserve">
     <value>GroupBox2</value>
@@ -714,14 +735,14 @@
   <data name="btnCalcKv.TabIndex" type="System.Int32, mscorlib">
     <value>39</value>
   </data>
-  <data name="GroupBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 503</value>
+  <data name="btnDisconnect1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="Label13.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;btnCreateAndConnectInlet1.Name" xml:space="preserve">
-    <value>btnCreateAndConnectInlet1</value>
+  <data name="cbPress.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="lblTag.Location" type="System.Drawing.Point, System.Drawing">
     <value>133, 19</value>
@@ -756,8 +777,8 @@
   <data name="btnCreateAndConnectInlet1.Size" type="System.Drawing.Size, System.Drawing">
     <value>21, 21</value>
   </data>
-  <data name="&gt;&gt;GroupBox3.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="Label7.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
   </data>
   <data name="Label19.Text" xml:space="preserve">
     <value>Corrente de Entrada</value>
@@ -780,8 +801,8 @@
   <data name="&gt;&gt;rtbAnnotations.Parent" xml:space="preserve">
     <value>GroupBox4</value>
   </data>
-  <data name="btnCalcKv.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="cbPress.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="cbPressureDropU.Items1" xml:space="preserve">
     <value>Média das Entradas</value>
@@ -804,11 +825,14 @@
   <data name="GroupBox5.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="&gt;&gt;rtbAnnotations.Type" xml:space="preserve">
-    <value>Extended.Windows.Forms.RichTextBoxExtended, RichTextBoxExtended, Version=2.0.2954.894, Culture=neutral, PublicKeyToken=null</value>
+  <data name="btnCreateAndConnectInlet1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>307, 23</value>
   </data>
   <data name="cbPressureDropU.ToolTip" xml:space="preserve">
     <value />
+  </data>
+  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="&gt;&gt;cbOutlet1.Parent" xml:space="preserve">
     <value>GroupBox1</value>
@@ -849,8 +873,8 @@
   <data name="&gt;&gt;tbOutletPressure.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="&gt;&gt;cbCalcMode.ZOrder" xml:space="preserve">
-    <value>14</value>
+  <data name="GroupBox5.Text" xml:space="preserve">
+    <value>Informações Gerais</value>
   </data>
   <data name="&gt;&gt;tbKvOpRel.ZOrder" xml:space="preserve">
     <value>3</value>
@@ -861,14 +885,8 @@
   <data name="&gt;&gt;btnCreateAndConnectOutlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cbOutlet1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 21</value>
-  </data>
-  <data name="btnConfigurePP.ToolTip2" xml:space="preserve">
-    <value>Configure</value>
-  </data>
-  <data name="Label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="tbOutletPressure.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
   </data>
   <data name="Label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -903,11 +921,8 @@
   <data name="cbPressureDropU.Items2" xml:space="preserve">
     <value>Máxima das Entradas</value>
   </data>
-  <data name="Label10.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;Label10.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="btnUtils.ToolTip1" xml:space="preserve">
+    <value>Add/View Utilities</value>
   </data>
   <data name="&gt;&gt;GroupBox2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -924,6 +939,12 @@
   <data name="&gt;&gt;cbFlashAlg.Parent" xml:space="preserve">
     <value>GroupBox3</value>
   </data>
+  <data name="&gt;&gt;cbPropPack.Name" xml:space="preserve">
+    <value>cbPropPack</value>
+  </data>
+  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>361, 83</value>
+  </data>
   <data name="Label10.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 13</value>
   </data>
@@ -939,20 +960,20 @@
   <data name="btnCalcKv.Size" type="System.Drawing.Size, System.Drawing">
     <value>88, 23</value>
   </data>
+  <data name="cbCalcMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>208, 21</value>
+  </data>
+  <data name="tbPressureDrop.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Right</value>
+  </data>
   <data name="Label12.Size" type="System.Drawing.Size, System.Drawing">
     <value>37, 13</value>
   </data>
   <data name="Label9.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
-  <data name="cbInlet1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 21</value>
-  </data>
   <data name="tbKvOpRel.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="chkActive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 21</value>
   </data>
   <data name="cbFlashAlg.ToolTip2" xml:space="preserve">
     <value />
@@ -981,9 +1002,6 @@
   <data name="&gt;&gt;Label11.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
-  <data name="tbKvOpRel.ToolTip1" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkEnableKvOpRel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1002,8 +1020,8 @@
   <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>92, 13</value>
   </data>
-  <data name="btnDisconnectOutlet1.ToolTip" xml:space="preserve">
-    <value>Desconectar</value>
+  <data name="chkEnableKvOpRel.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="chkActive.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -1017,20 +1035,14 @@
   <data name="&gt;&gt;Label13.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="btnDisconnect1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 74</value>
   </data>
-  <data name="btnCalcKv.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 94</value>
-  </data>
-  <data name="&gt;&gt;btnDisconnect1.Name" xml:space="preserve">
-    <value>btnDisconnect1</value>
-  </data>
-  <data name="GroupBox5.Text" xml:space="preserve">
-    <value>Informações Gerais</value>
-  </data>
-  <data name="GroupBox3.ToolTip1" xml:space="preserve">
+  <data name="tbOutletPressure.ToolTip1" xml:space="preserve">
     <value />
+  </data>
+  <data name="&gt;&gt;Label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="tbOutletPressure.ToolTip2" xml:space="preserve">
     <value />
@@ -1047,8 +1059,11 @@
   <data name="lblTag.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
   </data>
-  <data name="&gt;&gt;Label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;tbOp.Name" xml:space="preserve">
+    <value>tbOp</value>
+  </data>
+  <data name="&gt;&gt;btnDisconnectOutlet1.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbInlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 23</value>
@@ -1056,11 +1071,11 @@
   <data name="&gt;&gt;cbCalcMode.Name" xml:space="preserve">
     <value>cbCalcMode</value>
   </data>
-  <data name="&gt;&gt;cbInlet1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="cbCalcMode.ToolTip1" xml:space="preserve">
     <value />
+  </data>
+  <data name="&gt;&gt;btnDisconnect1.Name" xml:space="preserve">
+    <value>btnDisconnect1</value>
   </data>
   <data name="&gt;&gt;ToolTip1.Name" xml:space="preserve">
     <value>ToolTip1</value>
@@ -1077,17 +1092,14 @@
   <data name="&gt;&gt;btnCreateAndConnectOutlet1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="lblConnectedTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>132, 72</value>
-  </data>
   <data name="Label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="&gt;&gt;Label12.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="GroupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 189</value>
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
   <data name="cbOutlet1.ToolTip1" xml:space="preserve">
     <value />
@@ -1098,8 +1110,8 @@
   <data name="&gt;&gt;rtbAnnotations.Name" xml:space="preserve">
     <value>rtbAnnotations</value>
   </data>
-  <data name="GroupBox4.ToolTip" xml:space="preserve">
-    <value />
+  <data name="btnConfigurePP.ToolTip1" xml:space="preserve">
+    <value>Configure</value>
   </data>
   <data name="Label4.Size" type="System.Drawing.Size, System.Drawing">
     <value>210, 13</value>
@@ -1116,14 +1128,8 @@
   <data name="tbOutletPressure.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="Label9.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnConfigureFlashAlg.ToolTip1" xml:space="preserve">
-    <value>Configure</value>
-  </data>
-  <data name="Label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="chkEnableKvOpRel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 122</value>
   </data>
   <data name="&gt;&gt;chkActive.Parent" xml:space="preserve">
     <value>GroupBox5</value>
@@ -1136,6 +1142,9 @@
   </data>
   <data name="&gt;&gt;tbPressureDrop.ZOrder" xml:space="preserve">
     <value>12</value>
+  </data>
+  <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
   </data>
   <data name="rtbAnnotations.ToolTip1" xml:space="preserve">
     <value />
@@ -1167,6 +1176,9 @@
   <data name="Label9.ToolTip2" xml:space="preserve">
     <value />
   </data>
+  <data name="lblStatus.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
   <data name="&gt;&gt;btnConfigureFlashAlg.Parent" xml:space="preserve">
     <value>GroupBox3</value>
   </data>
@@ -1176,8 +1188,8 @@
   <data name="Label12.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>361, 83</value>
+  <data name="lblConnectedTo.Text" xml:space="preserve">
+    <value>Objeto</value>
   </data>
   <data name="UtilitiesCtxMenu.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 30</value>
@@ -1185,14 +1197,11 @@
   <data name="tbKv.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
   </data>
-  <data name="Label2.Text" xml:space="preserve">
-    <value>Pressão na Saída</value>
+  <data name="tbPressureDrop.Location" type="System.Drawing.Point, System.Drawing">
+    <value>148, 48</value>
   </data>
-  <data name="GroupBox5.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;Label9.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
+  <data name="cbCalcMode.Items4" xml:space="preserve">
+    <value>Kv para Vapor de Água (IEC 60534)</value>
   </data>
   <data name="GroupBox3.ToolTip" xml:space="preserve">
     <value />
@@ -1200,17 +1209,20 @@
   <data name="&gt;&gt;cbOutlet1.Name" xml:space="preserve">
     <value>cbOutlet1</value>
   </data>
+  <data name="Label8.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
   <data name="Label2.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;cbPropPack.Name" xml:space="preserve">
-    <value>cbPropPack</value>
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 13</value>
   </data>
   <data name="Label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;cbPropPack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="tbKv.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
   <data name="tbPressureDrop.Size" type="System.Drawing.Size, System.Drawing">
     <value>113, 20</value>
@@ -1220,9 +1232,6 @@
   </data>
   <data name="lblStatus.ToolTip1" xml:space="preserve">
     <value />
-  </data>
-  <data name="tbPressureDrop.TabIndex" type="System.Int32, mscorlib">
-    <value>25</value>
   </data>
   <data name="Label8.ToolTip" xml:space="preserve">
     <value />
@@ -1257,8 +1266,8 @@
   <data name="&gt;&gt;GroupBox3.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cbPropPack.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+  <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 13</value>
   </data>
   <data name="Label5.ToolTip" xml:space="preserve">
     <value />
@@ -1266,11 +1275,8 @@
   <data name="&gt;&gt;Label9.Name" xml:space="preserve">
     <value>Label9</value>
   </data>
-  <data name="&gt;&gt;lblTag.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="Label7.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 13</value>
   </data>
   <data name="cbOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 50</value>
@@ -1284,8 +1290,8 @@
   <data name="&gt;&gt;lblConnectedTo.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
-  <data name="Label8.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="tbOutletPressure.Location" type="System.Drawing.Point, System.Drawing">
+    <value>147, 72</value>
   </data>
   <data name="btnDisconnect1.Location" type="System.Drawing.Point, System.Drawing">
     <value>334, 23</value>
@@ -1299,17 +1305,14 @@
   <data name="btnDisconnect1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="GroupBox4.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkEnableKvOpRel.ToolTip" xml:space="preserve">
-    <value />
+  <data name="btnCreateAndConnectOutlet1.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
+    <value>Zoom</value>
   </data>
   <data name="btnCreateAndConnectInlet1.ToolTip2" xml:space="preserve">
     <value>Create and Connect</value>
   </data>
-  <data name="&gt;&gt;Label7.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="GroupBox4.Text" xml:space="preserve">
+    <value>Anotações Gerais</value>
   </data>
   <data name="&gt;&gt;tbKv.Name" xml:space="preserve">
     <value>tbKv</value>
@@ -1317,8 +1320,8 @@
   <data name="lblStatus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="cbPress.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="Label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="&gt;&gt;cbPress.Name" xml:space="preserve">
     <value>cbPress</value>
@@ -1338,9 +1341,6 @@
   <data name="Label5.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;Label11.Name" xml:space="preserve">
-    <value>Label11</value>
-  </data>
   <data name="cbInlet1.ToolTip1" xml:space="preserve">
     <value />
   </data>
@@ -1350,8 +1350,11 @@
   <data name="&gt;&gt;btnCreateAndConnectInlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="lblTag.Size" type="System.Drawing.Size, System.Drawing">
-    <value>195, 20</value>
+  <data name="lblTag.ToolTip1" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnCreateAndConnectInlet1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="&gt;&gt;cbOutlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1362,8 +1365,8 @@
   <data name="cbPressureDropU.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
   </data>
-  <data name="cbCalcMode.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="GroupBox5.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
   <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1371,29 +1374,17 @@
   <data name="$this.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="btnConfigurePP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>334, 26</value>
-  </data>
-  <data name="btnCreateAndConnectOutlet1.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
-    <value>Zoom</value>
-  </data>
-  <data name="&gt;&gt;tbKvOpRel.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
-  </data>
   <data name="btnConfigurePP.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
   </data>
   <data name="cbPropPack.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="Label12.ToolTip" xml:space="preserve">
-    <value />
+  <data name="Label2.Text" xml:space="preserve">
+    <value>Pressão na Saída</value>
   </data>
   <data name="Label2.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="AddUtilityTSMI.Text" xml:space="preserve">
-    <value>Adicionar Utilidade</value>
   </data>
   <data name="Label19.ToolTip1" xml:space="preserve">
     <value />
@@ -1401,17 +1392,20 @@
   <data name="Label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="Label19.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
+  <data name="cbCalcMode.Items3" xml:space="preserve">
+    <value>Kv para Gases (IEC 60534)</value>
+  </data>
   <data name="&gt;&gt;GroupBox1.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cbCalcMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 21</value>
+  <data name="chkEnableKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>229, 17</value>
   </data>
   <data name="tbPressureDrop.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
   </data>
   <data name="Label5.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 192</value>
@@ -1434,8 +1428,8 @@
   <data name="Label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Label4.Text" xml:space="preserve">
-    <value>Relação Kv/Kvmax (%) e Abertura (OP) (%)</value>
+  <data name="&gt;&gt;GroupBox3.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="lblStatus.Text" xml:space="preserve">
     <value>Objeto</value>
@@ -1449,38 +1443,29 @@
   <data name="Label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="tbOutletPressure.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="GroupBox5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>361, 98</value>
   </data>
-  <data name="Label4.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="btnConfigureFlashAlg.ToolTip1" xml:space="preserve">
+    <value>Configure</value>
   </data>
-  <data name="GroupBox1.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;cbCalcMode.ZOrder" xml:space="preserve">
+    <value>14</value>
   </data>
-  <data name="btnDisconnect1.ToolTip1" xml:space="preserve">
-    <value>Disconnect</value>
-  </data>
-  <data name="cbInlet1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="tbKv.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="Label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="Label11.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 22</value>
   </data>
-  <data name="GroupBox4.Text" xml:space="preserve">
-    <value>Anotações Gerais</value>
+  <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
-  <data name="btnConfigurePP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 21</value>
+  <data name="&gt;&gt;tbKvOpRel.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
   </data>
   <data name="&gt;&gt;cbPressureDropU.Parent" xml:space="preserve">
     <value>GroupBox2</value>
-  </data>
-  <data name="&gt;&gt;Label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="tbOutletPressure.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
@@ -1503,11 +1488,11 @@
   <data name="Label3.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="btnDisconnect1.ToolTip" xml:space="preserve">
-    <value>Desconectar</value>
+  <data name="lblConnectedTo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>132, 72</value>
   </data>
-  <data name="cbPress.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;btnCalcKv.Name" xml:space="preserve">
+    <value>btnCalcKv</value>
   </data>
   <data name="cbPressureDropU.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 21</value>
@@ -1521,8 +1506,14 @@
   <data name="btnCreateAndConnectOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>307, 50</value>
   </data>
-  <data name="btnUtils.ToolTip2" xml:space="preserve">
-    <value>Add/View Utilities</value>
+  <data name="tbKvOpRel.ToolTip1" xml:space="preserve">
+    <value />
+  </data>
+  <data name="&gt;&gt;cbPropPack.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbInlet1.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="Label8.Size" type="System.Drawing.Size, System.Drawing">
     <value>81, 13</value>
@@ -1548,8 +1539,8 @@
   <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="btnCreateAndConnectInlet1.TabIndex" type="System.Int32, mscorlib">
-    <value>45</value>
+  <data name="&gt;&gt;cbInlet1.Name" xml:space="preserve">
+    <value>cbInlet1</value>
   </data>
   <data name="&gt;&gt;GroupBox5.ZOrder" xml:space="preserve">
     <value>2</value>
@@ -1569,8 +1560,8 @@
   <data name="&gt;&gt;btnConfigureFlashAlg.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="GroupBox1.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="cbInlet1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 21</value>
   </data>
   <data name="Label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1578,8 +1569,8 @@
   <data name="lblConnectedTo.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="$this.ToolTip" xml:space="preserve">
-    <value />
+  <data name="cbInlet1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
   <data name="Label1.ToolTip1" xml:space="preserve">
     <value />
@@ -1596,26 +1587,29 @@
   <data name="lblConnectedTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="Label8.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+  <data name="&gt;&gt;Label11.Name" xml:space="preserve">
+    <value>Label11</value>
   </data>
-  <data name="btnDisconnect1.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+  <data name="btnCalcKv.Location" type="System.Drawing.Point, System.Drawing">
+    <value>265, 94</value>
   </data>
-  <data name="&gt;&gt;cbPress.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;Label10.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
-  <data name="Label1.Text" xml:space="preserve">
-    <value>Kv(max) (IEC 60534)</value>
+  <data name="btnConfigurePP.ToolTip2" xml:space="preserve">
+    <value>Configure</value>
   </data>
-  <data name="Label7.ToolTip" xml:space="preserve">
-    <value />
+  <data name="btnCreateAndConnectOutlet1.ToolTip" xml:space="preserve">
+    <value>Criar e Conectar</value>
+  </data>
+  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
   </data>
   <data name="cbOutlet1.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="tbPressureDrop.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Right</value>
+  <data name="&gt;&gt;chkActive.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbPress.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 21</value>
@@ -1623,11 +1617,8 @@
   <data name="&gt;&gt;tbOutletPressure.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label7.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;GroupBox5.Name" xml:space="preserve">
-    <value>GroupBox5</value>
+  <data name="btnConfigurePP.ToolTip" xml:space="preserve">
+    <value>Configurar</value>
   </data>
   <data name="tbKvOpRel.ToolTip2" xml:space="preserve">
     <value />
@@ -1635,8 +1626,8 @@
   <data name="tbOp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="Label8.Text" xml:space="preserve">
-    <value>Tipo de Cálculo</value>
+  <data name="GroupBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="Label3.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -1647,14 +1638,20 @@
   <data name="&gt;&gt;btnUtils.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
+  <data name="GroupBox2.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
   <data name="cbOutlet1.ToolTip" xml:space="preserve">
     <value />
   </data>
   <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>95, 13</value>
   </data>
-  <data name="GroupBox2.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="Label4.Text" xml:space="preserve">
+    <value>Relação Kv/Kvmax (%) e Abertura (OP) (%)</value>
+  </data>
+  <data name="btnConfigurePP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>334, 26</value>
   </data>
   <data name="&gt;&gt;Label1.Name" xml:space="preserve">
     <value>Label1</value>
@@ -1662,32 +1659,29 @@
   <data name="&gt;&gt;Label10.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label11.ZOrder" xml:space="preserve">
-    <value>7</value>
+  <data name="&gt;&gt;Label7.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
-  <data name="Label7.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;lblTag.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 98</value>
   </data>
-  <data name="Label2.ToolTip1" xml:space="preserve">
+  <data name="Label10.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="&gt;&gt;cbOutlet1.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;tbOutletPressure.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="&gt;&gt;Label8.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
   </data>
-  <data name="Label10.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="tbPressureDrop.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
   </data>
-  <data name="&gt;&gt;GroupBox1.Name" xml:space="preserve">
-    <value>GroupBox1</value>
-  </data>
-  <data name="btnUtils.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="&gt;&gt;cbPress.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="btnCreateAndConnectOutlet1.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -1698,17 +1692,17 @@
   <data name="&gt;&gt;cbCalcMode.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
+  <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
   </data>
-  <data name="&gt;&gt;cbInlet1.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;Label9.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
   </data>
   <data name="cbFlashAlg.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 53</value>
   </data>
-  <data name="GroupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 104</value>
+  <data name="GroupBox5.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;tbKvOpRel.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1725,8 +1719,8 @@
   <data name="btnConfigureFlashAlg.ToolTip2" xml:space="preserve">
     <value>Configure</value>
   </data>
-  <data name="lblStatus.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;Label11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1740,8 +1734,8 @@
   <data name="Label10.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="cbPressureDropU.Location" type="System.Drawing.Point, System.Drawing">
-    <value>266, 47</value>
+  <data name="chkActive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 21</value>
   </data>
   <data name="Label12.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1773,14 +1767,14 @@
   <data name="GroupBox1.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="Label19.ToolTip2" xml:space="preserve">
+  <data name="btnCalcKv.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="GroupBox3.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="cbCalcMode.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="lblTag.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="cbOutlet1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 21</value>
   </data>
   <data name="GroupBox4.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1794,17 +1788,20 @@
   <data name="chkEnableKvOpRel.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="chkEnableKvOpRel.ToolTip2" xml:space="preserve">
+  <data name="tbKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>343, 20</value>
+  </data>
+  <data name="&gt;&gt;cbInlet1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label10.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="GroupBox4.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="UtilitiesCtxMenu.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="btnCreateAndConnectOutlet1.ToolTip" xml:space="preserve">
-    <value>Criar e Conectar</value>
-  </data>
-  <data name="lblTag.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+  <data name="tbOutletPressure.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
   </data>
   <data name="Label5.Text" xml:space="preserve">
     <value>Abertura (%)</value>
@@ -1812,8 +1809,8 @@
   <data name="cbPropPack.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 26</value>
   </data>
-  <data name="cbFlashAlg.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+  <data name="AddUtilityTSMI.Text" xml:space="preserve">
+    <value>Adicionar Utilidade</value>
   </data>
   <data name="Label7.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 53</value>
@@ -1821,23 +1818,26 @@
   <data name="GroupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
-  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;tbOutletPressure.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
-  <data name="&gt;&gt;GroupBox1.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;Label7.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="GroupBox4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 503</value>
   </data>
   <data name="btnConfigureFlashAlg.Size" type="System.Drawing.Size, System.Drawing">
     <value>21, 21</value>
   </data>
-  <data name="cbPress.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;btnCreateAndConnectInlet1.Name" xml:space="preserve">
+    <value>btnCreateAndConnectInlet1</value>
   </data>
   <data name="&gt;&gt;rtbAnnotations.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="tbPressureDrop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>148, 48</value>
+  <data name="Label3.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="sizingtsmi.Text" xml:space="preserve">
     <value>Dimensionamento e Avaliação de PSVs</value>
@@ -1847,6 +1847,9 @@
   </data>
   <data name="Label10.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="cbFlashAlg.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
   <data name="&gt;&gt;Label19.Parent" xml:space="preserve">
     <value>GroupBox1</value>
@@ -1860,11 +1863,11 @@
   <data name="cbPress.Location" type="System.Drawing.Point, System.Drawing">
     <value>265, 72</value>
   </data>
-  <data name="tbOutletPressure.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 20</value>
+  <data name="&gt;&gt;GroupBox5.Name" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="&gt;&gt;sizingtsmi.Name" xml:space="preserve">
-    <value>sizingtsmi</value>
+  <data name="Label7.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <metadata name="ToolTipChangeTag.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>385, 17</value>

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.resx
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.resx
@@ -127,8 +127,8 @@
   <data name="&gt;&gt;tbOp.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="btnUtils.ToolTip2" xml:space="preserve">
-    <value>Add/View Utilities</value>
+  <data name="Label3.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="chkEnableKvOpRel.TabIndex" type="System.Int32, mscorlib">
@@ -153,11 +153,17 @@
   <data name="&gt;&gt;Label1.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="btnDisconnect1.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+  <data name="Label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnConfigurePP.ToolTip1" xml:space="preserve">
+    <value>Configure</value>
   </data>
   <data name="$this.ToolTip" xml:space="preserve">
     <value />
+  </data>
+  <data name="&gt;&gt;cbInlet1.Name" xml:space="preserve">
+    <value>cbInlet1</value>
   </data>
   <data name="btnDisconnectOutlet1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -174,23 +180,20 @@
   <data name="&gt;&gt;lblConnectedTo.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label11.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="&gt;&gt;AddUtilityTSMI.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;Label4.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
   <data name="Label13.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
   </data>
   <data name="&gt;&gt;btnUtils.Name" xml:space="preserve">
     <value>btnUtils</value>
-  </data>
-  <data name="GroupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 104</value>
   </data>
   <data name="tbKvOpRel.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
@@ -222,8 +225,8 @@
   <data name="&gt;&gt;btnDisconnectOutlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="Label9.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="GroupBox5.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
   <data name="AddUtilityTSMI.Size" type="System.Drawing.Size, System.Drawing">
     <value>179, 26</value>
@@ -234,17 +237,11 @@
   <data name="btnCalcKv.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;cbPropPack.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
-  <data name="Label1.Text" xml:space="preserve">
-    <value>Kv(max) (IEC 60534)</value>
-  </data>
   <data name="Label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;cbPress.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="GroupBox3.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="Label9.ToolTip1" xml:space="preserve">
     <value />
@@ -258,14 +255,17 @@
   <data name="&gt;&gt;GroupBox4.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="Label12.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;Label12.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="Label1.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
+  </data>
+  <data name="GroupBox5.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="GroupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -279,20 +279,11 @@
   <data name="cbPressureDropU.Items" xml:space="preserve">
     <value>Mínima das Entradas</value>
   </data>
-  <data name="&gt;&gt;sizingtsmi.Name" xml:space="preserve">
-    <value>sizingtsmi</value>
-  </data>
-  <data name="GroupBox1.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
   <data name="&gt;&gt;chkActive.Name" xml:space="preserve">
     <value>chkActive</value>
   </data>
   <data name="Label3.Text" xml:space="preserve">
     <value>Queda de Pressão</value>
-  </data>
-  <data name="cbCalcMode.ToolTip2" xml:space="preserve">
-    <value />
   </data>
   <data name="&gt;&gt;GroupBox5.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -321,8 +312,8 @@
   <data name="btnDisconnectOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>334, 50</value>
   </data>
-  <data name="btnDisconnect1.ToolTip" xml:space="preserve">
-    <value>Desconectar</value>
+  <data name="GroupBox4.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;Label5.Parent" xml:space="preserve">
     <value>GroupBox2</value>
@@ -330,17 +321,26 @@
   <data name="chkActive.ToolTip" xml:space="preserve">
     <value>Ativar/Desativar</value>
   </data>
+  <data name="&gt;&gt;UtilitiesCtxMenu.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="Label13.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="$this.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="Label9.Size" type="System.Drawing.Size, System.Drawing">
     <value>121, 13</value>
   </data>
-  <data name="&gt;&gt;Label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="Label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="btnDisconnectOutlet1.ToolTip" xml:space="preserve">
     <value>Desconectar</value>
+  </data>
+  <data name="cbPressureDropU.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
   </data>
   <data name="tbKvOpRel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -348,14 +348,14 @@
   <data name="&gt;&gt;Label5.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="Label7.ToolTip" xml:space="preserve">
+    <value />
+  </data>
   <data name="lblStatus.Location" type="System.Drawing.Point, System.Drawing">
     <value>132, 47</value>
   </data>
   <data name="&gt;&gt;GroupBox5.Parent" xml:space="preserve">
     <value>$this</value>
-  </data>
-  <data name="GroupBox4.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>EditingForm_Valve</value>
@@ -369,8 +369,8 @@
   <data name="&gt;&gt;lblStatus.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
-  <data name="&gt;&gt;btnCreateAndConnectOutlet1.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
+  <data name="&gt;&gt;btnCreateAndConnectInlet1.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="&gt;&gt;Label9.ZOrder" xml:space="preserve">
     <value>2</value>
@@ -387,26 +387,23 @@
   <data name="&gt;&gt;AddUtilityTSMI.Name" xml:space="preserve">
     <value>AddUtilityTSMI</value>
   </data>
+  <data name="&gt;&gt;ToolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="Label5.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="rtbAnnotations.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 171</value>
   </data>
-  <data name="Label7.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
   <data name="&gt;&gt;rtbAnnotations.Type" xml:space="preserve">
     <value>Extended.Windows.Forms.RichTextBoxExtended, RichTextBoxExtended, Version=2.0.2954.894, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="UtilitiesCtxMenu.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;cbPress.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
   <data name="cbInlet1.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="&gt;&gt;Label13.Parent" xml:space="preserve">
-    <value>GroupBox5</value>
   </data>
   <data name="&gt;&gt;tbPressureDrop.Name" xml:space="preserve">
     <value>tbPressureDrop</value>
@@ -417,14 +414,11 @@
   <data name="&gt;&gt;btnDisconnect1.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="Label8.Text" xml:space="preserve">
-    <value>Tipo de Cálculo</value>
+  <data name="tbKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>343, 20</value>
   </data>
   <data name="&gt;&gt;btnDisconnectOutlet1.Parent" xml:space="preserve">
     <value>GroupBox1</value>
-  </data>
-  <data name="&gt;&gt;tbKv.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="&gt;&gt;Label4.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -438,8 +432,14 @@
   <data name="Label4.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 145</value>
   </data>
+  <data name="chkEnableKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>229, 17</value>
+  </data>
   <data name="Label9.Text" xml:space="preserve">
     <value>Pacote de Propriedades</value>
+  </data>
+  <data name="GroupBox1.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="cbPressureDropU.ToolTip2" xml:space="preserve">
     <value />
@@ -456,11 +456,14 @@
   <data name="lblTag.Size" type="System.Drawing.Size, System.Drawing">
     <value>195, 20</value>
   </data>
-  <data name="GroupBox1.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 13</value>
   </data>
   <data name="tbKv.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
+  </data>
+  <data name="cbOutlet1.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="btnDisconnectOutlet1.Size" type="System.Drawing.Size, System.Drawing">
     <value>21, 21</value>
@@ -477,8 +480,8 @@
   <data name="chkActive.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;GroupBox1.Name" xml:space="preserve">
-    <value>GroupBox1</value>
+  <data name="lblConnectedTo.Text" xml:space="preserve">
+    <value>Objeto</value>
   </data>
   <data name="&gt;&gt;tbOp.ZOrder" xml:space="preserve">
     <value>1</value>
@@ -498,17 +501,20 @@
   <data name="&gt;&gt;chkEnableKvOpRel.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cbPressureDropU.Location" type="System.Drawing.Point, System.Drawing">
-    <value>266, 47</value>
-  </data>
   <data name="GroupBox5.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="Label4.ToolTip1" xml:space="preserve">
     <value />
   </data>
+  <data name="&gt;&gt;Label7.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
+  </data>
   <data name="btnConfigurePP.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>Stretch</value>
+  </data>
+  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 13</value>
   </data>
   <data name="&gt;&gt;Label4.Name" xml:space="preserve">
     <value>Label4</value>
@@ -534,7 +540,10 @@
   <data name="&gt;&gt;tbOp.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="Label8.ToolTip2" xml:space="preserve">
+  <data name="&gt;&gt;Label8.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="cbOutlet1.ToolTip" xml:space="preserve">
     <value />
   </data>
   <data name="&gt;&gt;tbKv.Type" xml:space="preserve">
@@ -546,14 +555,14 @@
   <data name="tbKv.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="btnConfigurePP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 21</value>
-  </data>
   <data name="&gt;&gt;btnCreateAndConnectOutlet1.Name" xml:space="preserve">
     <value>btnCreateAndConnectOutlet1</value>
   </data>
   <data name="btnDisconnect1.Size" type="System.Drawing.Size, System.Drawing">
     <value>21, 21</value>
+  </data>
+  <data name="&gt;&gt;chkActive.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="cbPropPack.ToolTip2" xml:space="preserve">
     <value />
@@ -576,8 +585,11 @@
   <data name="&gt;&gt;Label1.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="cbPropPack.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+  <data name="btnConfigurePP.ToolTip" xml:space="preserve">
+    <value>Configurar</value>
+  </data>
+  <data name="tbOutletPressure.Location" type="System.Drawing.Point, System.Drawing">
+    <value>147, 72</value>
   </data>
   <data name="&gt;&gt;Label3.Name" xml:space="preserve">
     <value>Label3</value>
@@ -597,17 +609,8 @@
   <data name="Label10.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 56</value>
   </data>
-  <data name="chkEnableKvOpRel.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
-  <data name="cbPress.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="tbKv.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="Label4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
   </data>
   <data name="GroupBox5.ToolTip2" xml:space="preserve">
     <value />
@@ -645,9 +648,6 @@
   <data name="GroupBox2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="lblTag.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
   <data name="&gt;&gt;btnCalcKv.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
@@ -663,8 +663,8 @@
   <data name="&gt;&gt;cbCalcMode.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="btnUtils.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
   <data name="btnUtils.Size" type="System.Drawing.Size, System.Drawing">
     <value>20, 20</value>
@@ -678,17 +678,14 @@
   <data name="&gt;&gt;Label2.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
+  <data name="&gt;&gt;btnCalcKv.Name" xml:space="preserve">
+    <value>btnCalcKv</value>
+  </data>
   <data name="GroupBox4.Size" type="System.Drawing.Size, System.Drawing">
     <value>361, 190</value>
   </data>
   <data name="Label13.ToolTip1" xml:space="preserve">
     <value />
-  </data>
-  <data name="cbCalcMode.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>372, 713</value>
   </data>
   <data name="cbPress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -699,20 +696,23 @@
   <data name="Label7.ToolTip1" xml:space="preserve">
     <value />
   </data>
+  <data name="cbFlashAlg.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="btnCreateAndConnectInlet1.ToolTip" xml:space="preserve">
+    <value>Criar e Conectar</value>
+  </data>
   <data name="btnCreateAndConnectInlet1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Label4.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;tbKv.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
+  <data name="btnConfigurePP.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="tbKv.Size" type="System.Drawing.Size, System.Drawing">
     <value>113, 20</value>
   </data>
-  <data name="GroupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 189</value>
+  <data name="GroupBox4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 503</value>
   </data>
   <data name="&gt;&gt;btnUtils.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -720,11 +720,11 @@
   <data name="btnCreateAndConnectOutlet1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
+  <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>38, 13</value>
+  </data>
   <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;GroupBox1.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="&gt;&gt;GroupBox2.Name" xml:space="preserve">
     <value>GroupBox2</value>
@@ -739,9 +739,6 @@
     <value>Top, Right</value>
   </data>
   <data name="Label13.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
-  <data name="cbPress.ToolTip2" xml:space="preserve">
     <value />
   </data>
   <data name="lblTag.Location" type="System.Drawing.Point, System.Drawing">
@@ -777,8 +774,8 @@
   <data name="btnCreateAndConnectInlet1.Size" type="System.Drawing.Size, System.Drawing">
     <value>21, 21</value>
   </data>
-  <data name="Label7.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+  <data name="cbInlet1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 21</value>
   </data>
   <data name="Label19.Text" xml:space="preserve">
     <value>Corrente de Entrada</value>
@@ -789,20 +786,14 @@
   <data name="GroupBox3.Text" xml:space="preserve">
     <value>Configurações do Pacote de Propriedades</value>
   </data>
-  <data name="Label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 72</value>
-  </data>
   <data name="Label2.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
   </data>
   <data name="&gt;&gt;GroupBox4.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;rtbAnnotations.Parent" xml:space="preserve">
-    <value>GroupBox4</value>
-  </data>
-  <data name="cbPress.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="btnCalcKv.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="cbPressureDropU.Items1" xml:space="preserve">
     <value>Média das Entradas</value>
@@ -831,9 +822,6 @@
   <data name="cbPressureDropU.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="&gt;&gt;cbOutlet1.Parent" xml:space="preserve">
     <value>GroupBox1</value>
   </data>
@@ -852,8 +840,8 @@
   <data name="lblConnectedTo.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;ToolTip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="Label13.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 72</value>
   </data>
   <data name="GroupBox3.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 414</value>
@@ -873,9 +861,6 @@
   <data name="&gt;&gt;tbOutletPressure.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="GroupBox5.Text" xml:space="preserve">
-    <value>Informações Gerais</value>
-  </data>
   <data name="&gt;&gt;tbKvOpRel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
@@ -885,8 +870,11 @@
   <data name="&gt;&gt;btnCreateAndConnectOutlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="tbOutletPressure.Size" type="System.Drawing.Size, System.Drawing">
-    <value>113, 20</value>
+  <data name="cbOutlet1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>154, 21</value>
+  </data>
+  <data name="Label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="Label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -924,26 +912,20 @@
   <data name="btnUtils.ToolTip1" xml:space="preserve">
     <value>Add/View Utilities</value>
   </data>
+  <data name="&gt;&gt;Label10.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="&gt;&gt;GroupBox2.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;Label10.Parent" xml:space="preserve">
     <value>GroupBox3</value>
   </data>
-  <data name="Label3.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="GroupBox2.ToolTip" xml:space="preserve">
     <value />
   </data>
   <data name="&gt;&gt;cbFlashAlg.Parent" xml:space="preserve">
     <value>GroupBox3</value>
-  </data>
-  <data name="&gt;&gt;cbPropPack.Name" xml:space="preserve">
-    <value>cbPropPack</value>
-  </data>
-  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>361, 83</value>
   </data>
   <data name="Label10.Size" type="System.Drawing.Size, System.Drawing">
     <value>78, 13</value>
@@ -960,12 +942,6 @@
   <data name="btnCalcKv.Size" type="System.Drawing.Size, System.Drawing">
     <value>88, 23</value>
   </data>
-  <data name="cbCalcMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 21</value>
-  </data>
-  <data name="tbPressureDrop.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
-    <value>Right</value>
-  </data>
   <data name="Label12.Size" type="System.Drawing.Size, System.Drawing">
     <value>37, 13</value>
   </data>
@@ -974,6 +950,9 @@
   </data>
   <data name="tbKvOpRel.ToolTip" xml:space="preserve">
     <value />
+  </data>
+  <data name="chkActive.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 21</value>
   </data>
   <data name="cbFlashAlg.ToolTip2" xml:space="preserve">
     <value />
@@ -1002,6 +981,9 @@
   <data name="&gt;&gt;Label11.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
+  <data name="tbKvOpRel.ToolTip1" xml:space="preserve">
+    <value />
+  </data>
   <data name="chkEnableKvOpRel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1011,17 +993,11 @@
   <data name="&gt;&gt;lblTag.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;lblConnectedTo.Name" xml:space="preserve">
-    <value>lblConnectedTo</value>
-  </data>
   <data name="cbPropPack.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="Label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>92, 13</value>
-  </data>
-  <data name="chkEnableKvOpRel.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkActive.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -1032,17 +1008,20 @@
   <data name="lblConnectedTo.Size" type="System.Drawing.Size, System.Drawing">
     <value>38, 13</value>
   </data>
-  <data name="&gt;&gt;Label13.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="Label2.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 74</value>
+  </data>
+  <data name="btnCalcKv.Location" type="System.Drawing.Point, System.Drawing">
+    <value>265, 94</value>
   </data>
   <data name="tbOutletPressure.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="&gt;&gt;Label7.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="GroupBox3.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="tbOutletPressure.ToolTip2" xml:space="preserve">
     <value />
@@ -1059,17 +1038,20 @@
   <data name="lblTag.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
   </data>
-  <data name="&gt;&gt;tbOp.Name" xml:space="preserve">
-    <value>tbOp</value>
-  </data>
-  <data name="&gt;&gt;btnDisconnectOutlet1.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;Label13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="cbInlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 23</value>
   </data>
   <data name="&gt;&gt;cbCalcMode.Name" xml:space="preserve">
     <value>cbCalcMode</value>
+  </data>
+  <data name="&gt;&gt;cbInlet1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Label7.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="cbCalcMode.ToolTip1" xml:space="preserve">
     <value />
@@ -1092,14 +1074,17 @@
   <data name="&gt;&gt;btnCreateAndConnectOutlet1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="lblConnectedTo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>132, 72</value>
+  </data>
   <data name="Label19.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;Label12.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;Label13.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;Label2.ZOrder" xml:space="preserve">
-    <value>10</value>
+  <data name="GroupBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 189</value>
   </data>
   <data name="cbOutlet1.ToolTip1" xml:space="preserve">
     <value />
@@ -1107,11 +1092,14 @@
   <data name="&gt;&gt;lblStatus.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="btnConfigureFlashAlg.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 21</value>
+  </data>
   <data name="&gt;&gt;rtbAnnotations.Name" xml:space="preserve">
     <value>rtbAnnotations</value>
   </data>
-  <data name="btnConfigurePP.ToolTip1" xml:space="preserve">
-    <value>Configure</value>
+  <data name="GroupBox4.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="Label4.Size" type="System.Drawing.Size, System.Drawing">
     <value>210, 13</value>
@@ -1122,20 +1110,23 @@
   <data name="Label9.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;UtilitiesCtxMenu.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="cbPress.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="tbOutletPressure.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="chkEnableKvOpRel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 122</value>
+  <data name="Label9.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnConfigureFlashAlg.ToolTip1" xml:space="preserve">
+    <value>Configure</value>
   </data>
   <data name="&gt;&gt;chkActive.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
-  <data name="&gt;&gt;btnDisconnect1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;btnCreateAndConnectOutlet1.Parent" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
   <data name="Label13.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1143,14 +1134,14 @@
   <data name="&gt;&gt;tbPressureDrop.ZOrder" xml:space="preserve">
     <value>12</value>
   </data>
-  <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
-  </data>
   <data name="rtbAnnotations.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="cbCalcMode.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
+  </data>
+  <data name="btnCreateAndConnectInlet1.ToolTip1" xml:space="preserve">
+    <value>Create and Connect</value>
   </data>
   <data name="cbInlet1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1160,9 +1151,6 @@
   </data>
   <data name="tbPressureDrop.ToolTip2" xml:space="preserve">
     <value />
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
   </data>
   <data name="btnUtils.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -1176,26 +1164,23 @@
   <data name="Label9.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="lblStatus.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;btnConfigureFlashAlg.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
-  </data>
   <data name="tbPressureDrop.ToolTip1" xml:space="preserve">
     <value />
   </data>
   <data name="Label12.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="lblConnectedTo.Text" xml:space="preserve">
-    <value>Objeto</value>
+  <data name="GroupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>361, 83</value>
   </data>
   <data name="UtilitiesCtxMenu.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 30</value>
   </data>
   <data name="tbKv.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
+  </data>
+  <data name="Label2.Text" xml:space="preserve">
+    <value>Pressão na Saída</value>
   </data>
   <data name="tbPressureDrop.Location" type="System.Drawing.Point, System.Drawing">
     <value>148, 48</value>
@@ -1215,8 +1200,8 @@
   <data name="Label2.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+  <data name="&gt;&gt;cbPropPack.Name" xml:space="preserve">
+    <value>cbPropPack</value>
   </data>
   <data name="Label11.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1229,9 +1214,6 @@
   </data>
   <data name="cbPress.Items" xml:space="preserve">
     <value>Mínima das Entradas</value>
-  </data>
-  <data name="lblStatus.ToolTip1" xml:space="preserve">
-    <value />
   </data>
   <data name="Label8.ToolTip" xml:space="preserve">
     <value />
@@ -1266,8 +1248,11 @@
   <data name="&gt;&gt;GroupBox3.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="Label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+  <data name="GroupBox5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>361, 98</value>
+  </data>
+  <data name="cbPropPack.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
   </data>
   <data name="Label5.ToolTip" xml:space="preserve">
     <value />
@@ -1275,8 +1260,11 @@
   <data name="&gt;&gt;Label9.Name" xml:space="preserve">
     <value>Label9</value>
   </data>
-  <data name="Label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 13</value>
+  <data name="&gt;&gt;lblTag.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="Label7.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
   </data>
   <data name="cbOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 50</value>
@@ -1290,8 +1278,8 @@
   <data name="&gt;&gt;lblConnectedTo.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
-  <data name="tbOutletPressure.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 72</value>
+  <data name="Label8.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="btnDisconnect1.Location" type="System.Drawing.Point, System.Drawing">
     <value>334, 23</value>
@@ -1320,8 +1308,8 @@
   <data name="lblStatus.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="Label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="cbPress.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;cbPress.Name" xml:space="preserve">
     <value>cbPress</value>
@@ -1341,6 +1329,9 @@
   <data name="Label5.ToolTip2" xml:space="preserve">
     <value />
   </data>
+  <data name="&gt;&gt;Label11.Name" xml:space="preserve">
+    <value>Label11</value>
+  </data>
   <data name="cbInlet1.ToolTip1" xml:space="preserve">
     <value />
   </data>
@@ -1349,9 +1340,6 @@
   </data>
   <data name="&gt;&gt;btnCreateAndConnectInlet1.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lblTag.ToolTip1" xml:space="preserve">
-    <value />
   </data>
   <data name="btnCreateAndConnectInlet1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
@@ -1362,26 +1350,32 @@
   <data name="tbOp.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="cbPressureDropU.TabIndex" type="System.Int32, mscorlib">
-    <value>26</value>
+  <data name="&gt;&gt;Label13.Parent" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
-  <data name="GroupBox5.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="cbCalcMode.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="$this.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;btnDisconnectOutlet1.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
-  <data name="btnConfigurePP.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+  <data name="btnConfigurePP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>334, 26</value>
+  </data>
+  <data name="&gt;&gt;tbKvOpRel.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
+  </data>
+  <data name="GroupBox5.Text" xml:space="preserve">
+    <value>Informações Gerais</value>
   </data>
   <data name="cbPropPack.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="Label2.Text" xml:space="preserve">
-    <value>Pressão na Saída</value>
+  <data name="Label12.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="Label2.ToolTip" xml:space="preserve">
     <value />
@@ -1389,11 +1383,11 @@
   <data name="Label19.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="Label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="Label1.Text" xml:space="preserve">
+    <value>Kv(max) (IEC 60534)</value>
   </data>
-  <data name="Label19.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="tbOutletPressure.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
   </data>
   <data name="cbCalcMode.Items3" xml:space="preserve">
     <value>Kv para Gases (IEC 60534)</value>
@@ -1401,11 +1395,14 @@
   <data name="&gt;&gt;GroupBox1.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chkEnableKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 17</value>
+  <data name="cbCalcMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>208, 21</value>
   </data>
   <data name="tbPressureDrop.ToolTip" xml:space="preserve">
     <value />
+  </data>
+  <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 13</value>
   </data>
   <data name="Label5.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 192</value>
@@ -1443,11 +1440,14 @@
   <data name="Label11.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="GroupBox5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>361, 98</value>
+  <data name="&gt;&gt;Label9.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
   </data>
-  <data name="btnConfigureFlashAlg.ToolTip1" xml:space="preserve">
-    <value>Configure</value>
+  <data name="Label4.ToolTip2" xml:space="preserve">
+    <value />
+  </data>
+  <data name="GroupBox1.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;cbCalcMode.ZOrder" xml:space="preserve">
     <value>14</value>
@@ -1461,17 +1461,20 @@
   <data name="lblStatus.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="&gt;&gt;tbKvOpRel.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
+  <data name="btnConfigurePP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>21, 21</value>
   </data>
   <data name="&gt;&gt;cbPressureDropU.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
+  <data name="&gt;&gt;Label11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tbOutletPressure.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
     <value>Right</value>
   </data>
-  <data name="cbFlashAlg.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;tbKv.Parent" xml:space="preserve">
+    <value>GroupBox2</value>
   </data>
   <data name="&gt;&gt;chkEnableKvOpRel.ZOrder" xml:space="preserve">
     <value>5</value>
@@ -1488,11 +1491,11 @@
   <data name="Label3.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="lblConnectedTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>132, 72</value>
+  <data name="btnDisconnect1.ToolTip" xml:space="preserve">
+    <value>Desconectar</value>
   </data>
-  <data name="&gt;&gt;btnCalcKv.Name" xml:space="preserve">
-    <value>btnCalcKv</value>
+  <data name="cbPress.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="cbPressureDropU.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 21</value>
@@ -1506,14 +1509,11 @@
   <data name="btnCreateAndConnectOutlet1.Location" type="System.Drawing.Point, System.Drawing">
     <value>307, 50</value>
   </data>
-  <data name="tbKvOpRel.ToolTip1" xml:space="preserve">
-    <value />
+  <data name="btnUtils.ToolTip2" xml:space="preserve">
+    <value>Add/View Utilities</value>
   </data>
   <data name="&gt;&gt;cbPropPack.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbInlet1.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="Label8.Size" type="System.Drawing.Size, System.Drawing">
     <value>81, 13</value>
@@ -1524,14 +1524,11 @@
   <data name="btnCalcKv.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;Label10.Name" xml:space="preserve">
-    <value>Label10</value>
+  <data name="&gt;&gt;btnConfigureFlashAlg.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
   </data>
-  <data name="btnConfigureFlashAlg.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
-    <value>Stretch</value>
-  </data>
-  <data name="Label4.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;rtbAnnotations.Parent" xml:space="preserve">
+    <value>GroupBox4</value>
   </data>
   <data name="GroupBox2.ToolTip1" xml:space="preserve">
     <value />
@@ -1539,8 +1536,8 @@
   <data name="Label2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;cbInlet1.Name" xml:space="preserve">
-    <value>cbInlet1</value>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
   </data>
   <data name="&gt;&gt;GroupBox5.ZOrder" xml:space="preserve">
     <value>2</value>
@@ -1554,14 +1551,17 @@
   <data name="cbPropPack.Size" type="System.Drawing.Size, System.Drawing">
     <value>181, 21</value>
   </data>
-  <data name="btnCreateAndConnectInlet1.ToolTip" xml:space="preserve">
-    <value>Criar e Conectar</value>
+  <data name="&gt;&gt;chkEnableKvOpRel.Name" xml:space="preserve">
+    <value>chkEnableKvOpRel</value>
+  </data>
+  <data name="&gt;&gt;Label10.Name" xml:space="preserve">
+    <value>Label10</value>
   </data>
   <data name="&gt;&gt;btnConfigureFlashAlg.Type" xml:space="preserve">
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cbInlet1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 21</value>
+  <data name="GroupBox1.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="Label8.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1581,35 +1581,35 @@
   <data name="&gt;&gt;Label2.Name" xml:space="preserve">
     <value>Label2</value>
   </data>
-  <data name="&gt;&gt;chkEnableKvOpRel.Name" xml:space="preserve">
-    <value>chkEnableKvOpRel</value>
+  <data name="btnConfigureFlashAlg.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
+    <value>Stretch</value>
   </data>
   <data name="lblConnectedTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;Label11.Name" xml:space="preserve">
-    <value>Label11</value>
+  <data name="chkEnableKvOpRel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 122</value>
   </data>
-  <data name="btnCalcKv.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 94</value>
+  <data name="btnDisconnect1.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
   </data>
-  <data name="&gt;&gt;Label10.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="&gt;&gt;cbPress.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="btnConfigurePP.ToolTip2" xml:space="preserve">
     <value>Configure</value>
   </data>
-  <data name="btnCreateAndConnectOutlet1.ToolTip" xml:space="preserve">
-    <value>Criar e Conectar</value>
+  <data name="tbPressureDrop.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
-  <data name="lblStatus.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="cbOutlet1.ToolTip2" xml:space="preserve">
+  <data name="lblStatus.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="&gt;&gt;chkActive.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="chkEnableKvOpRel.ToolTip" xml:space="preserve">
+    <value />
+  </data>
+  <data name="tbPressureDrop.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Right</value>
   </data>
   <data name="cbPress.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 21</value>
@@ -1617,8 +1617,11 @@
   <data name="&gt;&gt;tbOutletPressure.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="btnConfigurePP.ToolTip" xml:space="preserve">
-    <value>Configurar</value>
+  <data name="&gt;&gt;lblConnectedTo.Name" xml:space="preserve">
+    <value>lblConnectedTo</value>
+  </data>
+  <data name="&gt;&gt;GroupBox5.Name" xml:space="preserve">
+    <value>GroupBox5</value>
   </data>
   <data name="tbKvOpRel.ToolTip2" xml:space="preserve">
     <value />
@@ -1626,23 +1629,20 @@
   <data name="tbOp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="GroupBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="Label8.Text" xml:space="preserve">
+    <value>Tipo de Cálculo</value>
   </data>
   <data name="Label3.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
   </data>
-  <data name="&gt;&gt;btnCreateAndConnectInlet1.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;tbOp.Name" xml:space="preserve">
+    <value>tbOp</value>
   </data>
   <data name="&gt;&gt;btnUtils.Parent" xml:space="preserve">
     <value>GroupBox5</value>
   </data>
-  <data name="GroupBox2.ToolTip2" xml:space="preserve">
-    <value />
-  </data>
-  <data name="cbOutlet1.ToolTip" xml:space="preserve">
-    <value />
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>372, 713</value>
   </data>
   <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>95, 13</value>
@@ -1650,8 +1650,8 @@
   <data name="Label4.Text" xml:space="preserve">
     <value>Relação Kv/Kvmax (%) e Abertura (OP) (%)</value>
   </data>
-  <data name="btnConfigurePP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>334, 26</value>
+  <data name="GroupBox2.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="&gt;&gt;Label1.Name" xml:space="preserve">
     <value>Label1</value>
@@ -1659,11 +1659,11 @@
   <data name="&gt;&gt;Label10.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;Label7.Parent" xml:space="preserve">
-    <value>GroupBox1</value>
+  <data name="&gt;&gt;Label11.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="&gt;&gt;lblTag.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="Label7.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="Label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>8, 98</value>
@@ -1674,14 +1674,14 @@
   <data name="&gt;&gt;cbOutlet1.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="&gt;&gt;Label8.Parent" xml:space="preserve">
-    <value>GroupBox2</value>
+  <data name="Label4.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="tbPressureDrop.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
   </data>
-  <data name="&gt;&gt;cbPress.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="&gt;&gt;GroupBox1.Name" xml:space="preserve">
+    <value>GroupBox1</value>
   </data>
   <data name="btnCreateAndConnectOutlet1.TabIndex" type="System.Int32, mscorlib">
     <value>46</value>
@@ -1692,17 +1692,17 @@
   <data name="&gt;&gt;cbCalcMode.Parent" xml:space="preserve">
     <value>GroupBox2</value>
   </data>
-  <data name="Label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 13</value>
+  <data name="Label19.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 13</value>
   </data>
-  <data name="&gt;&gt;Label9.Parent" xml:space="preserve">
-    <value>GroupBox3</value>
+  <data name="&gt;&gt;cbInlet1.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="cbFlashAlg.Location" type="System.Drawing.Point, System.Drawing">
     <value>147, 53</value>
   </data>
-  <data name="GroupBox5.ToolTip" xml:space="preserve">
-    <value />
+  <data name="GroupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 104</value>
   </data>
   <data name="&gt;&gt;tbKvOpRel.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -1713,14 +1713,14 @@
   <data name="btnConfigureFlashAlg.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
   </data>
-  <data name="tbPressureDrop.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
+  <data name="&gt;&gt;btnDisconnect1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="btnConfigureFlashAlg.ToolTip2" xml:space="preserve">
     <value>Configure</value>
   </data>
-  <data name="&gt;&gt;Label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="lblStatus.ToolTip2" xml:space="preserve">
+    <value />
   </data>
   <data name="Label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1734,14 +1734,14 @@
   <data name="Label10.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="chkActive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 21</value>
+  <data name="cbPressureDropU.Location" type="System.Drawing.Point, System.Drawing">
+    <value>266, 47</value>
   </data>
   <data name="Label12.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="btnCreateAndConnectInlet1.ToolTip1" xml:space="preserve">
-    <value>Create and Connect</value>
+  <data name="btnUtils.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="&gt;&gt;btnDisconnect1.Parent" xml:space="preserve">
     <value>GroupBox1</value>
@@ -1764,17 +1764,17 @@
   <data name="Label5.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
   </data>
-  <data name="GroupBox1.ToolTip" xml:space="preserve">
+  <data name="Label3.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="btnCalcKv.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="GroupBox3.ToolTip1" xml:space="preserve">
+  <data name="Label19.ToolTip2" xml:space="preserve">
     <value />
   </data>
-  <data name="cbOutlet1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 21</value>
+  <data name="cbCalcMode.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="lblTag.ToolTip1" xml:space="preserve">
+    <value />
   </data>
   <data name="GroupBox4.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1788,20 +1788,20 @@
   <data name="chkEnableKvOpRel.ToolTip1" xml:space="preserve">
     <value />
   </data>
-  <data name="tbKvOpRel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 20</value>
+  <data name="chkEnableKvOpRel.ToolTip2" xml:space="preserve">
+    <value />
   </data>
-  <data name="&gt;&gt;cbInlet1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="UtilitiesCtxMenu.ToolTip" xml:space="preserve">
+    <value />
   </data>
   <data name="Label10.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="GroupBox4.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="btnCreateAndConnectOutlet1.ToolTip" xml:space="preserve">
+    <value>Criar e Conectar</value>
   </data>
-  <data name="tbOutletPressure.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
+  <data name="lblTag.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
   <data name="Label5.Text" xml:space="preserve">
     <value>Abertura (%)</value>
@@ -1821,14 +1821,14 @@
   <data name="&gt;&gt;tbOutletPressure.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="&gt;&gt;Label7.ZOrder" xml:space="preserve">
-    <value>4</value>
+  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="GroupBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 503</value>
+  <data name="&gt;&gt;GroupBox1.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="btnConfigureFlashAlg.Size" type="System.Drawing.Size, System.Drawing">
-    <value>21, 21</value>
+  <data name="&gt;&gt;tbKv.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="&gt;&gt;btnCreateAndConnectInlet1.Name" xml:space="preserve">
     <value>btnCreateAndConnectInlet1</value>
@@ -1836,8 +1836,8 @@
   <data name="&gt;&gt;rtbAnnotations.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="Label3.ToolTip2" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;cbPropPack.Parent" xml:space="preserve">
+    <value>GroupBox3</value>
   </data>
   <data name="sizingtsmi.Text" xml:space="preserve">
     <value>Dimensionamento e Avaliação de PSVs</value>
@@ -1863,11 +1863,11 @@
   <data name="cbPress.Location" type="System.Drawing.Point, System.Drawing">
     <value>265, 72</value>
   </data>
-  <data name="&gt;&gt;GroupBox5.Name" xml:space="preserve">
-    <value>GroupBox5</value>
+  <data name="tbOutletPressure.Size" type="System.Drawing.Size, System.Drawing">
+    <value>113, 20</value>
   </data>
-  <data name="Label7.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;sizingtsmi.Name" xml:space="preserve">
+    <value>sizingtsmi</value>
   </data>
   <metadata name="ToolTipChangeTag.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>385, 17</value>

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.vb
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.vb
@@ -124,12 +124,14 @@ Public Class EditingForm_Valve
                     cbCalcMode.SelectedIndex = 0
                 Case UnitOperations.Valve.CalculationMode.DeltaP
                     cbCalcMode.SelectedIndex = 1
-                Case UnitOperations.Valve.CalculationMode.Kv_Liquid
+                Case UnitOperations.Valve.CalculationMode.Kv_General
                     cbCalcMode.SelectedIndex = 2
-                Case UnitOperations.Valve.CalculationMode.Kv_Gas
-                    cbCalcMode.SelectedIndex = 3
                 Case UnitOperations.Valve.CalculationMode.Kv_Steam
+                    cbCalcMode.SelectedIndex = 3
+                Case UnitOperations.Valve.CalculationMode.Kv_Liquid
                     cbCalcMode.SelectedIndex = 4
+                Case UnitOperations.Valve.CalculationMode.Kv_Gas
+                    cbCalcMode.SelectedIndex = 5
             End Select
 
             tbOutletPressure.Text = su.Converter.ConvertFromSI(units.pressure, uobj.OutletPressure.GetValueOrDefault).ToString(nf)
@@ -182,18 +184,18 @@ Public Class EditingForm_Valve
                 tbKv.Enabled = False
                 tbKvOpRel.Enabled = False
                 tbOp.Enabled = False
-                chkEnableKvOpRel.Enabled = False
+                chkEnableKvOpRel.Enabled = True
                 SimObject.CalcMode = UnitOperations.Valve.CalculationMode.OutletPressure
-                btnCalcKv.Enabled = False
+                btnCalcKv.Enabled = True
             Case 1
                 tbPressureDrop.Enabled = True
                 tbOutletPressure.Enabled = False
                 tbKv.Enabled = False
                 tbKvOpRel.Enabled = False
                 tbOp.Enabled = False
-                chkEnableKvOpRel.Enabled = False
+                chkEnableKvOpRel.Enabled = True
                 SimObject.CalcMode = UnitOperations.Valve.CalculationMode.DeltaP
-                btnCalcKv.Enabled = False
+                btnCalcKv.Enabled = True
             Case 2
                 tbPressureDrop.Enabled = False
                 tbOutletPressure.Enabled = False
@@ -201,7 +203,7 @@ Public Class EditingForm_Valve
                 tbKvOpRel.Enabled = True
                 tbOp.Enabled = True
                 chkEnableKvOpRel.Enabled = True
-                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Liquid
+                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_General
                 btnCalcKv.Enabled = True
             Case 3
                 tbPressureDrop.Enabled = False
@@ -210,7 +212,7 @@ Public Class EditingForm_Valve
                 tbKvOpRel.Enabled = True
                 tbOp.Enabled = True
                 chkEnableKvOpRel.Enabled = True
-                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Gas
+                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Steam
                 btnCalcKv.Enabled = True
             Case 4
                 tbPressureDrop.Enabled = False
@@ -219,7 +221,16 @@ Public Class EditingForm_Valve
                 tbKvOpRel.Enabled = True
                 tbOp.Enabled = True
                 chkEnableKvOpRel.Enabled = True
-                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Steam
+                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Liquid
+                btnCalcKv.Enabled = True
+            Case 5
+                tbPressureDrop.Enabled = False
+                tbOutletPressure.Enabled = False
+                tbKv.Enabled = True
+                tbKvOpRel.Enabled = True
+                tbOp.Enabled = True
+                chkEnableKvOpRel.Enabled = True
+                SimObject.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Gas
                 btnCalcKv.Enabled = True
         End Select
 
@@ -259,11 +270,13 @@ Public Class EditingForm_Valve
             Case 1
                 uobj.CalcMode = UnitOperations.Valve.CalculationMode.DeltaP
             Case 2
-                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Liquid
+                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_General
             Case 3
-                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Gas
-            Case 4
                 uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Steam
+            Case 4
+                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Liquid
+            Case 5
+                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Gas
         End Select
 
         If sender Is tbOutletPressure Then uobj.OutletPressure = su.Converter.ConvertToSI(cbPress.SelectedItem.ToString, tbOutletPressure.Text.ParseExpressionToDouble)
@@ -494,7 +507,7 @@ Public Class EditingForm_Valve
 
     End Sub
 
-    Private Sub Button1_Click(sender As Object, e As EventArgs) Handles btnCalcKv.Click
+    Private Sub btnCalcKv_Click(sender As Object, e As EventArgs) Handles btnCalcKv.Click
 
         SimObject.CalculateKv()
 

--- a/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.vb
+++ b/DWSIM.UnitOperations/Editing Forms/EditingForm_Valve.vb
@@ -270,13 +270,13 @@ Public Class EditingForm_Valve
             Case 1
                 uobj.CalcMode = UnitOperations.Valve.CalculationMode.DeltaP
             Case 2
-                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_General
-            Case 3
-                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Steam
-            Case 4
                 uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Liquid
-            Case 5
+            Case 3
                 uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Gas
+            Case 4
+                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_Steam
+            Case 5
+                uobj.CalcMode = UnitOperations.Valve.CalculationMode.Kv_General
         End Select
 
         If sender Is tbOutletPressure Then uobj.OutletPressure = su.Converter.ConvertToSI(cbPress.SelectedItem.ToString, tbOutletPressure.Text.ParseExpressionToDouble)

--- a/DWSIM.UnitOperations/Unit Operations/Pipe.vb
+++ b/DWSIM.UnitOperations/Unit Operations/Pipe.vb
@@ -1467,7 +1467,7 @@ Namespace UnitOperations
 
         Shared Function hint_petukhov(ByVal k, ByVal D, ByVal f, ByVal NRe, ByVal NPr)
 
-            hint_petukhov = k / D * (f / 8) * NRe * NPr / (1.07 + 12.7 * (f / 8) ^ 0.5 * (NPr ^ (2 / 3) - 1))
+            hint_petukhov = k / D * (f / 8) * (NRe - 1000.0) * NPr / (1.0 + 12.7 * (f / 8) ^ 0.5 * (NPr ^ (2 / 3) - 1))
 
         End Function
 

--- a/DWSIM.UnitOperations/Unit Operations/Valve.vb
+++ b/DWSIM.UnitOperations/Unit Operations/Valve.vb
@@ -48,6 +48,18 @@ Namespace UnitOperations
 
         Public Property OpeningPct As Double = 50.0
 
+        Public Property xT As Double = 0.75
+
+        Public Property FL As Double = 0.9
+
+        Public Property FP As Double = 1.0
+
+        Public Property Fs As Double = 1.0
+
+        Public Property Fi As Double = 0.9
+
+        Public Property N6 As Double = 31.6
+
         Public Property PercentOpeningVersusPercentKvExpression As String = "1.0*OP"
 
         Public Property EnableOpeningKvRelationship As Boolean = False
@@ -55,9 +67,10 @@ Namespace UnitOperations
         Public Enum CalculationMode
             DeltaP = 0
             OutletPressure = 1
-            Kv_Liquid = 2
-            Kv_Gas = 3
-            Kv_Steam = 4
+            Kv_General = 2
+            Kv_Steam = 3
+            Kv_Liquid = 4
+            Kv_Gas = 5
         End Enum
 
         Public Sub New()
@@ -153,7 +166,8 @@ Namespace UnitOperations
                     Dim ims As MaterialStream = Me.GetInletMaterialStream(0)
                     Dim oms As MaterialStream = Me.GetOutletMaterialStream(0)
 
-                    Dim Ti, P1, Hi, Wi, ei, ein, P2, H2, rho, volf, rhog20, P2ant, v2, Kvc As Double
+                    Dim Ti, P1, Hi, Wi, ei, ein, P2, H2, rho, volf, rhog20, P2ant, v2, Kvc, Pv, Pc, rhol, rhog, k, Cp_ig As Double
+                    Dim massfrac_gas, massfrac_liq As Double
                     Dim icount As Integer
 
                     Me.PropertyPackage.CurrentMaterialStream = ims
@@ -199,15 +213,40 @@ Namespace UnitOperations
 
                         P2 = oms.GetPressure
 
-                        If CalcMode = CalculationMode.Kv_Liquid Then
-                            Wi = Kvc * (1000.0 * rho * (P1 - P2) / 100000.0) ^ 0.5 / 3600
-                        ElseIf CalcMode = CalculationMode.Kv_Gas Then
-                            ims.PropertyPackage.CurrentMaterialStream = ims
-                            rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
-                            If P2 > P1 / 2 Then
-                                Wi = 519 * Kvc / (Ti / (rhog20 * (P1 - P2) / 100000.0 * P1 / 100000.0)) ^ 0.5 / 3600
+                        If CalcMode = CalculationMode.Kv_General Or CalculationMode.Kv_Gas Or CalculationMode.Kv_Liquid Then
+                            If ims.Phases(1).Properties.molarfraction = 1 Then
+                                Pv = ims.PropertyPackage.AUX_PVAPM(Ti)
+                                Pc = ims.PropertyPackage.AUX_PCM(PropertyPackages.Phase.Liquid)
+                                rhol = ims.Phases(1).Properties.density.GetValueOrDefault
+
+                                Wi = WLiquid(Kvc, P1 / 100000.0, P2 / 100000.0, rhol, Pv / 100000.0, Pc / 100000.0)
+                                Wi = Kvc * (1000.0 * rho * (P1 - P2) / 100000.0) ^ 0.5 / 3600
+                            ElseIf ims.Phases(2).Properties.molarfraction = 1 Then
+                                ims.PropertyPackage.CurrentMaterialStream = ims
+                                rhog = ims.PropertyPackage.AUX_VAPDENS(Ti, P1)
+                                Cp_ig = ims.PropertyPackage.AUX_CPm(PropertyPackages.Phase.Vapor, Ti) * ims.Phases(2).Properties.molecularWeight()
+                                k = Cp_ig / (Cp_ig - 8.314)
+                                Wi = WGas(Kvc, P1 / 100000.0, P2 / 100000.0, k, rhog)
+
+                                rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
+                                If P2 > P1 / 2 Then
+                                    Wi = 519 * Kvc / (Ti / (rhog20 * (P1 - P2) / 100000.0 * P1 / 100000.0)) ^ 0.5 / 3600
+                                Else
+                                    Wi = 259.5 * Kvc * P1 / 100000.0 / (Ti / rhog20) ^ 0.5 / 3600
+                                End If
                             Else
-                                Wi = 259.5 * Kvc * P1 / 100000.0 / (Ti / rhog20) ^ 0.5 / 3600
+                                ims.PropertyPackage.CurrentMaterialStream = ims
+                                rhog = ims.Phases(2).Properties.density.GetValueOrDefault
+                                Cp_ig = ims.PropertyPackage.AUX_CPm(PropertyPackages.Phase.Vapor, Ti) * ims.Phases(2).Properties.molecularWeight()
+                                k = Cp_ig / (Cp_ig - 8.314)
+                                rhol = ims.Phases(1).Properties.density.GetValueOrDefault
+                                Pc = ims.PropertyPackage.AUX_PCM(PropertyPackages.Phase.Liquid)
+                                Pv = ims.PropertyPackage.AUX_PVAPM(PropertyPackages.Phase.Liquid, Ti)
+
+                                massfrac_gas = ims.Phases(2).Properties.massflow.GetValueOrDefault / ims.Phases(0).Properties.massflow.GetValueOrDefault
+                                massfrac_liq = ims.Phases(1).Properties.massflow.GetValueOrDefault / ims.Phases(0).Properties.massflow.GetValueOrDefault
+
+                                Wi = WTwoPhase(Kvc, P1 / 100000.0, P2 / 100000.0, rhog, rhol, k, Pv / 100000.0, Pc / 100000.0, massfrac_gas, massfrac_liq)
                             End If
                         ElseIf CalcMode = CalculationMode.Kv_Steam Then
                             If P2 > P1 / 2 Then
@@ -235,12 +274,16 @@ Namespace UnitOperations
 
                         P2 = oms.GetPressure()
 
-                        If CalcMode = CalculationMode.Kv_Liquid Then
-                            P1 = P2 / 100000.0 + 1 / (1000.0 * rho) * (Wi * 3600 / Kvc) ^ 2
-                        ElseIf CalcMode = CalculationMode.Kv_Gas Then
-                            ims.PropertyPackage.CurrentMaterialStream = ims
-                            rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
-                            P1 = P2 / 100000.0 + Ti / rhog20 / (P2 / 100000) * (519 * Kvc / (Wi * 3600)) ^ -2
+                        If CalcMode = CalculationMode.Kv_General Or CalculationMode.Kv_Gas Or CalculationMode.Kv_Liquid Then
+                            If ims.Phases(1).Properties.molarfraction = 1 Then
+                                P1 = P2 / 100000.0 + 1 / (1000.0 * rho) * (Wi * 3600 / Kvc) ^ 2
+                            ElseIf ims.Phases(2).Properties.molarfraction = 1 Then
+                                ims.PropertyPackage.CurrentMaterialStream = ims
+                                rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
+                                P1 = P2 / 100000.0 + Ti / rhog20 / (P2 / 100000) * (519 * Kvc / (Wi * 3600)) ^ -2
+                            Else
+                                Throw New Exception("Two-phase not supported for given P/F spec.")
+                            End If
                         ElseIf CalcMode = CalculationMode.Kv_Steam Then
                             v2 = 1 / ims.PropertyPackage.AUX_VAPDENS(Ti, P2)
                             P1 = P2 / 100000.0 + v2 * (31.62 * Kvc / (Wi * 3600)) ^ -2
@@ -258,19 +301,23 @@ Namespace UnitOperations
 
                         'valid! calculate P2
 
-                        If CalcMode = CalculationMode.Kv_Liquid Then
-                            P2 = P1 / 100000.0 - 1 / (1000.0 * rho) * (Wi * 3600 / Kvc) ^ 2
-                            P2 = P2 * 100000.0
-                        ElseIf CalcMode = CalculationMode.Kv_Gas Then
-                            ims.PropertyPackage.CurrentMaterialStream = ims
-                            rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
-                            Dim roots = MathOps.Quadratic.quadForm(-rhog20, rhog20 * P1 / 100000, -Ti * (519 * Kvc / (Wi * 3600)) ^ -2)
-                            If roots.Item1 > 0 And roots.Item1 > P1 / 100000 / 2 Then
-                                P2 = roots.Item1 * 100000.0
-                            ElseIf roots.Item2 > 0 And roots.Item2 > P1 / 100000 / 2 Then
-                                P2 = roots.Item2 * 100000.0
+                        If CalcMode = CalculationMode.Kv_General Or CalculationMode.Kv_Gas Or CalculationMode.Kv_Liquid Then
+                            If ims.Phases(1).Properties.molarfraction = 1 Then
+                                P2 = P1 / 100000.0 - 1 / (1000.0 * rho) * (Wi * 3600 / Kvc) ^ 2
+                                P2 = P2 * 100000.0
+                            ElseIf ims.Phases(2).Properties.molarfraction = 1 Then
+                                ims.PropertyPackage.CurrentMaterialStream = ims
+                                rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
+                                Dim roots = MathOps.Quadratic.quadForm(-rhog20, rhog20 * P1 / 100000, -Ti * (519 * Kvc / (Wi * 3600)) ^ -2)
+                                If roots.Item1 > 0 And roots.Item1 > P1 / 100000 / 2 Then
+                                    P2 = roots.Item1 * 100000.0
+                                ElseIf roots.Item2 > 0 And roots.Item2 > P1 / 100000 / 2 Then
+                                    P2 = roots.Item2 * 100000.0
+                                Else
+                                    Throw New Exception("Unable to calculate the outlet pressure.")
+                                End If
                             Else
-                                Throw New Exception("Unable to calculate the outlet pressure.")
+                                Throw New Exception("Two-phase not supported for given P/F spec.")
                             End If
                         ElseIf CalcMode = CalculationMode.Kv_Steam Then
                             P2 = P1 * 0.7 / 100000.0
@@ -284,7 +331,6 @@ Namespace UnitOperations
                             Loop Until Math.Abs(P2 - P2ant) < 0.0001
                             P2 = P2 * 100000.0
                         End If
-
                     End If
 
                     DeltaP = P1 - P2
@@ -322,9 +368,183 @@ Namespace UnitOperations
 
         End Sub
 
+        Public Function SimpleKvLiquid(Wi As Double, rho As Double, P1 As Double, P2 As Double) As Double
+
+            SimpleKvLiquid = Wi * 3600 / (1000.0 * rho * (P1 - P2) / 100000.0) ^ 0.5
+        End Function
+
+        Public Function SimpleKvGas(Wi As Double, rhog20 As Double, P1 As Double, P2 As Double, Ti As Double) As Double
+            If P2 > P1 / 2 Then
+                SimpleKvGas = Wi * 3600 / 519 * (Ti / (rhog20 * (P1 - P2) / 100000.0 * P2 / 100000.0)) ^ 0.5
+            Else
+                SimpleKvGas = Wi * 3600 / 259.5 / P1 * (Ti / rhog20) ^ 0.5
+            End If
+        End Function
+
+        Public Function F_k(k As Double) As Double
+
+            F_k = k / 1.4
+
+        End Function
+
+        Public Function Y_factor(x As Double, k As Double, xT As Double) As Double
+            Y_factor = 1 - x / (3 * x_choked(k, xT))
+
+        End Function
+
+        Public Function x_ratio(P1 As Double, P2 As Double) As Double
+
+            x_ratio = (P1 - P2) / P1
+
+        End Function
+
+        Public Function x_choked(k As Double, xT As Double) As Double
+            x_choked = F_k(k) * xT
+        End Function
+
+
+        Public Function F_F(Pv As Double, Pc As Double) As Double
+
+            F_F = 0.96 - 0.28 * (Pv / Pc) ^ 0.5
+
+        End Function
+
+        Public Function KvTwoPhase(Wi As Double, P1 As Double, P2 As Double, rhog As Double, rhol As Double, k As Double, Pv As Double, Pc As Double, massfrac_gas As Double, massfrac_liq As Double) As Double
+
+            KvTwoPhase = (massfrac_gas * KvGas(Wi, P1, P2, k, rhog) ^ 2 + massfrac_liq * KvLiquid(Wi, P1, P2, rhol, Pv, Pc) ^ 2) ^ 0.5
+        End Function
+
+        Public Function WTwoPhase(Kv As Double, P1 As Double, P2 As Double, rhog As Double, rhol As Double, k As Double, Pv As Double, Pc As Double, massfrac_gas As Double, massfrac_liq As Double) As Double
+            WTwoPhase = ((massfrac_liq / WLiquid(Kv, P1, P2, rhol, Pv, Pc)) + massfrac_gas / WGas(Kv, P1, P2, k, rhog)) ^ -0.5
+        End Function
+
+        Public Function KvLiquid(Wi As Double, P1 As Double, P2 As Double, rho As Double, Pv As Double, Pc As Double) As Double
+            Dim dP_choke
+
+            dP_choke = FL ^ 2 * (P1 - F_F(Pv, Pc) * Pv)
+            If dP_choke < (P1 - P2) Then
+                P2 = P1 - dP_choke
+            End If
+
+            KvLiquid = Wi / FP / (rho * 999.1 * (P1 - P2)) ^ 0.5
+
+        End Function
+
+        Public Function WLiquid(Kv As Double, P1 As Double, P2 As Double, rho As Double, Pv As Double, Pc As Double) As Double
+            Dim dP_choke
+
+            dP_choke = FL ^ 2 * (P1 - F_F(Pv, Pc) * Pv)
+            If dP_choke < (P1 - P2) Then
+                P2 = P1 - dP_choke
+            End If
+            WLiquid = Kv * FP * (rho * 999.1 * (P1 - P2)) ^ 0.5
+
+        End Function
+
+        Public Function P2TwoPhase(Wi As Double, Kv As Double, P1 As Double, rhog As Double, rhol As Double, k As Double, Pv As Double, Pc As Double, massfrac_gas As Double, massfrac_liq As Double) As Double
+            Dim P2_high, P2_low, P2_mid, x_c As Double
+            Dim icount As Integer
+
+            x_c = x_choked(k, xT)
+            P2_high = P1
+            P2_low = P2_high - P2_high * x_c
+
+            If P2_low < P1 - FL ^ 2 * (P1 - F_F(Pv, Pc) * Pv) Then
+                P2_low = P1 - FL ^ 2 * (P1 - F_F(Pv, Pc) * Pv)
+            End If
+
+            If WTwoPhase(Kv, P1, P2_low, rhog, rhol, k, Pv, Pc, massfrac_gas, massfrac_liq) < Wi Then
+                Throw New Exception("Valve capacity too small, increase Kv")
+            Else
+                Do While Math.Abs(P2_high - P2_low) > 0.001
+                    P2_mid = (P2_high + P2_low) / 2
+                    If WTwoPhase(Kv, P1, P2_mid, rhog, rhol, k, Pv, Pc, massfrac_gas, massfrac_liq) > Wi Then
+                        P2_low = P2_mid
+                    Else
+                        P2_high = P2_mid
+                    End If
+                    If icount > 1000 Then Throw New Exception("P2 did not converge in 1000 iterations.")
+                    icount += 1
+                Loop
+            End If
+            P2TwoPhase = (P2_high + P2_low) / 2
+        End Function
+
+        Public Function P2Liquid(Wi As Double, Kv As Double, P1 As Double, rho As Double, Pv As Double, Pc As Double) As Double
+            Dim P2_high, P2_low, P2_mid, x_c As Double
+
+            P2_high = P1
+            P2_low = P1 - FL ^ 2 * (P1 - F_F(Pv, Pc) * Pv)
+
+            If Kv * FP * (rho * 999.1 * (P1 - P2_low)) ^ 0.5 < Wi Then
+                Throw New Exception("Valve capacity too small, increase Kv")
+            Else
+                P2Liquid = P1 - 1 / (999.1 * rho) * (Wi / (Kv * FP)) ^ 2
+            End If
+
+        End Function
+
+        Public Function KvGas(Wi As Double, P1 As Double, P2 As Double, k As Double, rho As Double)
+            Dim Y, x, x_c As Double
+
+            x = x_ratio(P1, P2)
+            x_c = x_choked(k, xT)
+
+            If x > x_c Then
+                x = x_c
+            End If
+
+            Y = Y_factor(x, k, xT)
+
+            KvGas = Wi * 1 / (N6 * FP * Y) / (x * P1 * rho) ^ 0.5
+        End Function
+
+        Public Function WGas(Kv As Double, P1 As Double, P2 As Double, k As Double, rho As Double)
+            Dim Y, x, x_c As Double
+
+            x = x_ratio(P1, P2)
+            x_c = x_choked(k, xT)
+
+            If x > x_c Then
+                x = x_c
+            End If
+
+            Y = Y_factor(x, k, xT)
+
+            WGas = Kv * (N6 * FP * Y) * (x * P1 * rho) ^ 0.5
+        End Function
+
+
+        Public Function P2_Gas(Wi As Double, Kv As Double, P1 As Double, k As Double, rho As Double)
+            Dim P2_high, P2_low, P2_mid, x_c As Double
+            Dim icount As Integer
+
+            x_c = x_choked(k, xT)
+            P2_high = P1
+            P2_low = P2_high - P2_high * x_c
+
+            icount = 0
+            If (Kv * N6 * FP * Y_factor(x_c, k, xT) * (x_c * P1 * rho) ^ 0.5) < Wi Then
+                Throw New Exception("Valve capacity too small, increase Kv")
+            Else
+                Do While Math.Abs(P2_high - P2_low) > 0.001
+                    P2_mid = (P2_high + P2_low) / 2
+                    If WGas(Kv, P1, P2_mid, k, rho) > Wi Then
+                        P2_low = P2_mid
+                    Else
+                        P2_high = P2_mid
+                    End If
+                    If icount > 1000 Then Throw New Exception("P2 did not converge in 1000 iterations.")
+                    icount += 1
+                Loop
+            End If
+            P2_Gas = (P2_high + P2_low) / 2
+        End Function
+
         Public Sub CalculateKv()
 
-            Dim Ti, P1, Hi, Wi, ei, P2, rho, volf, rhog20, v2 As Double
+            Dim Ti, P1, Hi, Wi, ei, P2, rho, rhog20, rhog, rhol, volf, k, v2, Cp_ig, Pv, Pc As Double
+            Dim massfrac_liq, massfrac_gas As Double
 
             Dim ims As MaterialStream = Me.GetInletMaterialStream(0)
             Dim oms As MaterialStream = Me.GetOutletMaterialStream(0)
@@ -342,17 +562,7 @@ Namespace UnitOperations
 
             P2 = oms.Phases(0).Properties.pressure.GetValueOrDefault
 
-            If CalcMode = CalculationMode.Kv_Liquid Then
-                Kv = Wi * 3600 / (1000.0 * rho * (P1 - P2) / 100000.0) ^ 0.5
-            ElseIf CalcMode = CalculationMode.Kv_Gas Then
-                ims.PropertyPackage.CurrentMaterialStream = ims
-                rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
-                If P2 > P1 / 2 Then
-                    Kv = Wi * 3600 / 519 * (Ti / (rhog20 * (P1 - P2) / 100000.0 * P2 / 100000.0)) ^ 0.5
-                Else
-                    Kv = Wi * 3600 / 259.5 / P1 * (Ti / rhog20) ^ 0.5
-                End If
-            ElseIf CalcMode = CalculationMode.Kv_Steam Then
+            If CalcMode = CalculationMode.Kv_Steam Then
                 If P2 > P1 / 2 Then
                     v2 = 1 / ims.PropertyPackage.AUX_VAPDENS(Ti, P2)
                     Kv = Wi * 3600 / 31.62 * (v2 / ((P1 - P2) / 100000.0)) ^ 0.5
@@ -360,6 +570,49 @@ Namespace UnitOperations
                     v2 = 1 / ims.PropertyPackage.AUX_VAPDENS(Ti, P1 / 2)
                     Kv = Wi * 3600 / 31.62 * (2 * v2 / (P1 / 100000.0)) ^ 0.5
                 End If
+            Else
+                If ims.Phases(2).Properties.molarfraction = 1 Then
+                    ims.PropertyPackage.CurrentMaterialStream = ims
+                    rho = ims.PropertyPackage.AUX_VAPDENS(Ti, P1)
+
+                    Cp_ig = ims.PropertyPackage.AUX_CPm(PropertyPackages.Phase.Vapor, Ti) * ims.Phases(2).Properties.molecularWeight()
+                    k = Cp_ig / (Cp_ig - 8.314)
+                    Kv = KvGas(Wi * 3600, P1 / 100000.0, P2 / 100000.0, k, rho)
+                ElseIf ims.Phases(1).Properties.molarfraction = 1 Then
+                    Pv = ims.PropertyPackage.AUX_PVAPM(Ti)
+                    Pc = ims.PropertyPackage.AUX_PCM(PropertyPackages.Phase.Liquid)
+                    rho = ims.Phases(1).Properties.density.GetValueOrDefault
+                    Kv = KvLiquid(Wi * 3600, P1 / 100000.0, P2 / 100000.0, rho, Pv / 100000.0, Pc / 100000.0)
+                Else
+                    ims.PropertyPackage.CurrentMaterialStream = ims
+                    rhog = ims.Phases(2).Properties.density.GetValueOrDefault
+                    Cp_ig = ims.PropertyPackage.AUX_CPm(PropertyPackages.Phase.Vapor, Ti) * ims.Phases(2).Properties.molecularWeight()
+                    k = Cp_ig / (Cp_ig - 8.314)
+                    rhol = ims.Phases(1).Properties.density.GetValueOrDefault
+                    Pc = ims.PropertyPackage.AUX_PCM(PropertyPackages.Phase.Liquid)
+                    Pv = ims.PropertyPackage.AUX_PVAPM(PropertyPackages.Phase.Liquid, Ti)
+
+                    massfrac_gas = ims.Phases(2).Properties.massflow.GetValueOrDefault / ims.Phases(0).Properties.massflow.GetValueOrDefault
+                    massfrac_liq = ims.Phases(1).Properties.massflow.GetValueOrDefault / ims.Phases(0).Properties.massflow.GetValueOrDefault
+
+                    Kv = KvTwoPhase(Wi * 3600, P1 / 100000.0, P2 / 100000.0, rhog, rhol, k, Pv / 100000.0, Pc / 100000.0, massfrac_gas, massfrac_liq)
+                End If
+            End If
+
+            If EnableOpeningKvRelationship Then
+                Try
+                    Dim ExpContext As New Ciloci.Flee.ExpressionContext
+                    ExpContext.Imports.AddType(GetType(System.Math))
+                    ExpContext.Variables.Clear()
+                    ExpContext.Options.ParseCulture = Globalization.CultureInfo.InvariantCulture
+                    ExpContext.Variables.Add("OP", OpeningPct)
+
+                    Dim Expr = ExpContext.CompileGeneric(Of Double)(PercentOpeningVersusPercentKvExpression)
+                    Kv = Kv / (Expr.Evaluate() / 100)
+
+                Catch ex As Exception
+                    Throw New Exception("Invalid expression for Kv/Opening relationship.")
+                End Try
             End If
 
         End Sub
@@ -390,6 +643,7 @@ Namespace UnitOperations
             End If
 
             Dim Ti, Pi, Hi, Wi, ei, ein, T2, P2, H2, H2c, rho, volf, rhog20, P2ant, v2, Kvc, T2est As Double
+            Dim Cp_ig, k, Pv, Pc, rhog, rhol, massfrac_gas, massfrac_liq As Double
             Dim icount As Integer
 
             Dim ims, oms As MaterialStream
@@ -454,30 +708,24 @@ Namespace UnitOperations
 
             'reference: https://www.samson.de/document/t00050en.pdf
 
-            If CalcMode = CalculationMode.Kv_Gas Or CalcMode = CalculationMode.Kv_Liquid Or CalcMode = CalculationMode.Kv_Steam Then
+            If CalcMode = CalculationMode.Kv_General Or CalcMode = CalculationMode.Kv_Steam Then
                 IObj?.Paragraphs.Add("<h2>Kv Calculation Mode</h2>")
-                IObj?.Paragraphs.Add("Kv flow equations in DWSIM are implemented as per IEC 60534 for non-critical flow (P2 > 0.5*P1).")
-                IObj?.Paragraphs.Add("For more information, see <a href='https://www.samson.de/document/t00050en.pdf'>this document</a>.")
+                IObj?.Paragraphs.Add("Kv flow equations in DWSIM are implemented as per ANSI/ISA-75.01.01 and IEC 60534-2-1 for turbulent flow.")
+                IObj?.Paragraphs.Add("Kv for two-phase service is adapted from Masoneilan and is eqivalent to other vendor equations e.g. Valtek, Parcol and Warren Controls.")
+                IObj?.Paragraphs.Add("See <a href='https://dam.bakerhughes.com/m/47616eb160214a1d/original/MN-Valve-Sizing-Handbook-GEA19540A-English-pdf.pdf' > Masoneilan Control Valve Sizing Handbook</a> for more information on general valve sizing.")
+                IObj?.Paragraphs.Add("For more information on simplified steam service sizing, see <a href='https://www.samson.de/document/t00050en.pdf'>this document</a>.")
+                IObj?.Paragraphs.Add("The folowwing default valve style modifiers are applied:")
+                IObj?.Paragraphs.Add("<mi>x_T= 0.75</mi>")
+                IObj?.Paragraphs.Add("<mi>F_L = 0.9</mi>")
+                IObj?.Paragraphs.Add("<mi>F_P = 1.0</mi>")
+                IObj?.Paragraphs.Add("<mi>F_s = 1.0</mi>")
+                IObj?.Paragraphs.Add("<mi>F_i = 0.9</mi>")
+
                 IObj?.Paragraphs.Add(String.Format("Kv = {0}", Kvc))
             End If
 
-            If CalcMode = CalculationMode.Kv_Liquid Then
-                P2 = Pi / 100000.0 - 1 / (1000.0 * rho) * (Wi * 3600 / Kvc) ^ 2
-                P2 = P2 * 100000.0
-                IObj?.Paragraphs.Add(String.Format("Calculated Outlet Pressure P2 = {0} Pa", P2))
-            ElseIf CalcMode = CalculationMode.Kv_Gas Then
-                ims.PropertyPackage.CurrentMaterialStream = ims
-                rhog20 = ims.PropertyPackage.AUX_VAPDENS(273.15, 101325)
-                Dim roots = MathOps.Quadratic.quadForm(-rhog20, rhog20 * Pi / 100000, -Ti * (519 * Kvc / (Wi * 3600)) ^ -2)
-                If roots.Item1 > 0 And roots.Item1 > Pi / 100000 / 2 Then
-                    P2 = roots.Item1 * 100000.0
-                ElseIf roots.Item2 > 0 And roots.Item2 > Pi / 100000 / 2 Then
-                    P2 = roots.Item2 * 100000.0
-                Else
-                    Throw New Exception("Unable to calculate the outlet pressure.")
-                End If
-                IObj?.Paragraphs.Add(String.Format("Calculated Outlet Pressure P2 = {0} Pa", P2))
-            ElseIf CalcMode = CalculationMode.Kv_Steam Then
+
+            If CalcMode = CalculationMode.Kv_Steam Then
                 P2 = Pi * 0.7 / 100000.0
                 icount = 0
                 Do
@@ -489,6 +737,33 @@ Namespace UnitOperations
                 Loop Until Math.Abs(P2 - P2ant) < 0.0001
                 P2 = P2 * 100000.0
                 IObj?.Paragraphs.Add(String.Format("Calculated Outlet Pressure P2 = {0} Pa", P2))
+            ElseIf CalcMode = CalculationMode.Kv_General Or CalculationMode.Kv_Gas Or CalculationMode.Kv_Liquid Then
+                If ims.Phases(2).Properties.molarfraction = 1 Then
+                    ims.PropertyPackage.CurrentMaterialStream = ims
+                    rhog = ims.PropertyPackage.AUX_VAPDENS(Ti, Pi)
+                    Cp_ig = ims.PropertyPackage.AUX_CPm(PropertyPackages.Phase.Vapor, Ti) * ims.Phases(2).Properties.molecularWeight()
+                    k = Cp_ig / (Cp_ig - 8.314)
+                    P2 = P2_Gas(Wi * 3600, Kvc, Pi / 100000.0, k, rhog) * 100000.0
+                    IObj?.Paragraphs.Add(String.Format("Calculated Outlet Pressure P2 = {0} Pa", P2))
+                ElseIf ims.Phases(1).Properties.molarfraction = 1 Then
+                    Pv = ims.PropertyPackage.AUX_PVAPM(Ti)
+                    Pc = ims.PropertyPackage.AUX_PCM(PropertyPackages.Phase.Liquid)
+                    rhol = ims.Phases(1).Properties.density.GetValueOrDefault
+                    P2 = 100000.0 * P2Liquid(Wi * 3600, Kvc, Pi / 100000.0, rhol, Pv / 100000.0, Pc / 100000.0)
+                    IObj?.Paragraphs.Add(String.Format("Calculated Outlet Pressure P2 = {0} Pa", P2))
+                Else
+                    ims.PropertyPackage.CurrentMaterialStream = ims
+                    rhog = ims.Phases(2).Properties.density.GetValueOrDefault
+                    Cp_ig = ims.PropertyPackage.AUX_CPm(PropertyPackages.Phase.Vapor, Ti) * ims.Phases(2).Properties.molecularWeight()
+                    k = Cp_ig / (Cp_ig - 8.314)
+                    rhol = ims.Phases(1).Properties.density.GetValueOrDefault
+                    Pc = ims.PropertyPackage.AUX_PCM(PropertyPackages.Phase.Liquid)
+                    Pv = ims.PropertyPackage.AUX_PVAPM(PropertyPackages.Phase.Liquid, Ti)
+
+                    massfrac_gas = ims.Phases(2).Properties.massflow.GetValueOrDefault / ims.Phases(0).Properties.massflow.GetValueOrDefault
+                    massfrac_liq = ims.Phases(1).Properties.massflow.GetValueOrDefault / ims.Phases(0).Properties.massflow.GetValueOrDefault
+                    P2 = 100000.0 * P2TwoPhase(Wi * 3600, Kvc, Pi / 100000.0, rhog, rhol, k, Pv / 100000.0, Pc / 100000.0, massfrac_gas, massfrac_liq)
+                End If
             End If
 
             If Me.CalcMode = CalculationMode.DeltaP Then
@@ -529,7 +804,7 @@ Namespace UnitOperations
 
             'If herr > 0.01 Then Throw New Exception("The enthalpy of inlet and outlet streams doesn't match. Result is invalid.")
 
-            Me.DeltaT = T2 - Ti
+                Me.DeltaT = T2 - Ti
             Me.DeltaQ = 0
 
             OutletTemperature = T2

--- a/DWSIM.UnitOperations/Unit Operations/Valve.vb
+++ b/DWSIM.UnitOperations/Unit Operations/Valve.vb
@@ -67,10 +67,10 @@ Namespace UnitOperations
         Public Enum CalculationMode
             DeltaP = 0
             OutletPressure = 1
-            Kv_General = 2
-            Kv_Steam = 3
-            Kv_Liquid = 4
-            Kv_Gas = 5
+            Kv_General = 5
+            Kv_Steam = 4
+            Kv_Liquid = 2
+            Kv_Gas = 3
         End Enum
 
         Public Sub New()

--- a/DWSIM/Forms/Flowsheet Components/FlowsheetSurface_SkiaSharp/FlowsheetSurface_SkiaSharp.vb
+++ b/DWSIM/Forms/Flowsheet Components/FlowsheetSurface_SkiaSharp/FlowsheetSurface_SkiaSharp.vb
@@ -3035,11 +3035,7 @@ Public Class FlowsheetSurface_SkiaSharp
 
             id = AddObjectToSurface(ObjectType.Valve, x, y, False)
             Dim valve = DirectCast(Flowsheet.SimulationObjects(id), Valve)
-            If istream.Phases(2).Properties.molarfraction.GetValueOrDefault >= 0.5 Then
-                valve.CalcMode = Valve.CalculationMode.Kv_Gas
-            Else
-                valve.CalcMode = Valve.CalculationMode.Kv_Liquid
-            End If
+            valve.CalcMode = Valve.CalculationMode.Kv_General
             valve.Kv = 2.0
             valve.EnableOpeningKvRelationship = True
             valve.OpeningPct = 50

--- a/DWSIM/Forms/LegacyEditors/PropertyEditors/PropertyGridEditors.vb
+++ b/DWSIM/Forms/LegacyEditors/PropertyEditors/PropertyGridEditors.vb
@@ -4986,7 +4986,7 @@ Public Class PropertyGridEditors
                         .CustomEditor = New DWSIM.Editors.Generic.UIUnitConverter
                     End With
 
-                Case Valve.CalculationMode.Kv_Gas, Valve.CalculationMode.Kv_Liquid, Valve.CalculationMode.Kv_Steam
+                Case Valve.CalculationMode.Kv_General, Valve.CalculationMode.Kv_Gas, Valve.CalculationMode.Kv_Liquid, Valve.CalculationMode.Kv_Steam
 
                     .Item.Add("Kv (max)", uo, "Kv", False, DWSIM.App.GetLocalString("Parmetrosdeclculo2"), "", True)
                     .Item.Add("Use Kv versus Opening relatioship", uo, "EnableOpeningKvRelationship", False, DWSIM.App.GetLocalString("Parmetrosdeclculo2"), "", True)
@@ -5035,7 +5035,7 @@ Public Class PropertyGridEditors
                             .CustomEditor = New DWSIM.Editors.Generic.UIUnitConverter
                         End With
 
-                    Case Valve.CalculationMode.Kv_Gas, Valve.CalculationMode.Kv_Liquid, Valve.CalculationMode.Kv_Steam
+                    Case Valve.CalculationMode.Kv_General, Valve.CalculationMode.Kv_Gas, Valve.CalculationMode.Kv_Liquid, Valve.CalculationMode.Kv_Steam
 
                         valor = Format(Converter.ConvertFromSI(su.pressure, uo.OutletPressure.GetValueOrDefault), uo.FlowSheet.Options.NumberFormat)
                         .Item.Add(FT(DWSIM.App.GetLocalString("ValveOutletPressure"), su.pressure), valor, False, DWSIM.App.GetLocalString("Resultados3"), "", True)


### PR DESCRIPTION
Hi Daniel, a rather large chunk. We can wait till after 6.4 release, if you are busy. Anyway, a more rigorous valve sizing based on the full IEC/ANSI/ISA standard for both choked/non-choked conditions and Masoneilan two-phase, fully implemented for steady-state sizing. Gas, liquid sizing validated against Unisim and in-house calculation. Two-phase give a littler smaller values than Unisim (Which I suspect are using the older Fischer two-phase correction factor). The user can now also estimate Kvmax when the valve is specified for oulet pressure or dP. 
In dynamics I have kept the more simple formulas, I believe they are adequate for the level detail needed for dyanmic simulations, however, the multiphase model is also implemented both for P1, P2 and Wi as output. The P1 estimate is a not very beutiful Newton-like damped solver (not my proudest moment). 