### PR TITLE
Easy build configuration with xcopy of common dll files and directories

### DIFF
--- a/DWSIM/DWSIM.vbproj
+++ b/DWSIM/DWSIM.vbproj
@@ -444,7 +444,6 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.XML" />

--- a/DWSIM/DWSIM.vbproj
+++ b/DWSIM/DWSIM.vbproj
@@ -37,6 +37,10 @@
     </UpgradeBackupLocation>
     <ApplicationManifest>My Project\app.manifest</ApplicationManifest>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -51,10 +55,6 @@
     <ApplicationVersion>0.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -444,6 +444,7 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.XML" />
@@ -3524,6 +3525,9 @@ erase /S /Q "$(SolutionDir)DistPackages\Linux\*.dat" 2&gt;nul 1&gt;nul 4&gt;nul
 xcopy "$(TargetDir)\*" "$(SolutionDir)DistPackages\Windows\" /E /Y /F /D
 xcopy "$(TargetDir)\*" "$(SolutionDir)DistPackages\macOS\" /E /Y /F /D
 
+xcopy "$(SolutionDir)\PlatformFiles\Common" "$(TargetDir)"  /E /Y /F /D
+xcopy "$(SolutionDir)\PlatformFiles\Windows" "$(TargetDir)"  /E /Y /F /D
+
 erase /S /Q "$(SolutionDir)DistPackages\Windows\DWSIM.vshost.*" 2&gt;nul 1&gt;nul 4&gt;nul
 erase /S /Q "$(SolutionDir)DistPackages\Windows\*.tmp" 2&gt;nul 1&gt;nul 4&gt;nul
 erase /S /Q "$(SolutionDir)DistPackages\Windows\*.dylib" 2&gt;nul 1&gt;nul 4&gt;nul
@@ -3534,6 +3538,9 @@ erase /S /Q "$(SolutionDir)DistPackages\macOS\*.tmp" 2&gt;nul 1&gt;nul 4&gt;nul
 ) else if "$(PlatformName)"=="x86" (
 
 xcopy "$(TargetDir)\*" "$(SolutionDir)DistPackages\Windows_32\" /E /Y /F /D
+
+xcopy "$(SolutionDir)\PlatformFiles\Common" "$(TargetDir)"  /E /Y /F /D
+xcopy "$(SolutionDir)\PlatformFiles\Windows32" "$(TargetDir)"  /E /Y /F /D
 
 erase /S /Q "$(SolutionDir)DistPackages\Windows_32\DWSIM.vshost.*" 2&gt;nul 1&gt;nul 4&gt;nul
 erase /S  /Q "$(SolutionDir)DistPackages\Windows_32\*.tmp" 2&gt;nul 1&gt;nul 4&gt;nul

--- a/DWSIM/app.config
+++ b/DWSIM/app.config
@@ -1,245 +1,248 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="DWSIM.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-        </sectionGroup>
-        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="DWSIM.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-        </sectionGroup>
-    </configSections>
-    <system.diagnostics>
-        <sources>
-            <!-- This section defines the logging configuration for My.Application.Log -->
-            <source name="DefaultSource" switchName="DefaultSwitch">
-                <listeners>
-                    <add name="FileLog" />
-                    <!-- Uncomment the below section to write to the Application Event Log -->
-                    <!--<add name="EventLog"/>-->
-                </listeners>
-            </source>
-        </sources>
-        <switches>
-            <add name="DefaultSwitch" value="Information" />
-        </switches>
-        <sharedListeners>
-            <add name="FileLog" type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" initializeData="FileLogWriter" />
-            <!-- Uncomment the below section and replace APPLICATION_NAME with the name of your application to write to the Application Event Log -->
-            <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
-        </sharedListeners>
-    </system.diagnostics>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup><userSettings>
-        <DWSIM.My.MySettings>
-            <setting name="UserUnits" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="ShowTips" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="BackupFolder" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="BackupActivated" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="BackupInterval" serializeAs="String">
-                <value>5</value>
-            </setting>
-            <setting name="CultureInfo" serializeAs="String">
-                <value>en</value>
-            </setting>
-            <setting name="ChemSepDatabasePath" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="ReplaceComps" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="RedirectOutput" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="CheckForUpdates" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="UpgradeRequired" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="EnableParallelProcessing" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="MaxDegreeOfParallelism" serializeAs="String">
-                <value>-1</value>
-            </setting>
-            <setting name="EnableGPUProcessing" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="SelectedGPU" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="CudafyTarget" serializeAs="String">
-                <value>1</value>
-            </setting>
-            <setting name="CudafyDeviceID" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="ShowCoolPropWarning" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="SolverMode" serializeAs="String">
-                <value>1</value>
-            </setting>
-            <setting name="ServiceBusConnectionString" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="DebugLevel" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="ServerIPAddress" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="ServerPort" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="SolverTimeoutSeconds" serializeAs="String">
-                <value>360</value>
-            </setting>
-            <setting name="SolverBreakOnException" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="StorePreviousSolutions" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="ShowWhatsNew" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="SaveBackupFile" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="MaxThreadMultiplier" serializeAs="String">
-                <value>8</value>
-            </setting>
-            <setting name="TaskScheduler" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="UseSIMDExtensions" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="ShowSimulationToolStrip" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="ShowFlowsheetToolStrip" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="ShowUnitsToolStrip" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="ClipboardCopyMode_Compounds" serializeAs="String">
-                <value>1</value>
-            </setting>
-            <setting name="ClipboardCopyMode_PropertyPackages" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="UndoRedo_RecalculateFlowsheet" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="MostRecentFiles" serializeAs="Xml">
-                <value>
-                    <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
-                </value>
-            </setting>
-            <setting name="ObjectSelectorSplitterDistance1" serializeAs="String">
-                <value>351</value>
-            </setting>
-            <setting name="ObjectSelectorSplitterDistance2" serializeAs="String">
-                <value>86</value>
-            </setting>
-            <setting name="ObjectSelectorSplitterDistance3" serializeAs="String">
-                <value>84</value>
-            </setting>
-            <setting name="CloseFormsOnDeselecting" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="DefaultEditorLocation" serializeAs="String">
-                <value>8</value>
-            </setting>
-            <setting name="AutomaticUpdates" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="EnableMultipleObjectEditors" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="SimulationUpgradeWarning" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="HideSolidPhase_CO" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="IgnoreCompoundPropertiesOnLoad" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="OctavePath" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="OctaveProcessTimeout" serializeAs="String">
-                <value>15</value>
-            </setting>
-            <setting name="CurrentPlatform" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="CurrentEnvironment" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="PythonPath" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="PythonProcessTimeout" serializeAs="String">
-                <value>1</value>
-            </setting>
-            <setting name="InspectorEnabled" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="ObjectEditor" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="DisplayPFDTip" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="FlowsheetRenderer" serializeAs="String">
-                <value>0</value>
-            </setting>
-            <setting name="FlowsheetAntiAliasing" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="DoubleClickToEdit" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="SendCrashAndUsageAnalytics" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="UserEmail" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="ShowDataCollectionForm" serializeAs="String">
-                <value>True</value>
-            </setting>
-        </DWSIM.My.MySettings>
-    </userSettings>
-    <applicationSettings>
-        <DWSIM.My.MySettings>
-            <setting name="PreviewVersion" serializeAs="String">
-                <value />
-            </setting>
-            <setting name="Key1" serializeAs="String">
-                <value>51d86903-c99d-4710-a7f0-a38a447e436a</value>
-            </setting>
-            <setting name="Key2" serializeAs="String">
-                <value>c9c40f22-ee70-44bb-8654-b177db105878
+  <configSections>
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="DWSIM.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+    </sectionGroup>
+    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="DWSIM.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+  <system.diagnostics>
+    <sources>
+      <!-- This section defines the logging configuration for My.Application.Log -->
+      <source name="DefaultSource" switchName="DefaultSwitch">
+        <listeners>
+          <add name="FileLog" />
+          <!-- Uncomment the below section to write to the Application Event Log -->
+          <!--<add name="EventLog"/>-->
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="DefaultSwitch" value="Information" />
+    </switches>
+    <sharedListeners>
+      <add name="FileLog" type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" initializeData="FileLogWriter" />
+      <!-- Uncomment the below section and replace APPLICATION_NAME with the name of your application to write to the Application Event Log -->
+      <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
+    </sharedListeners>
+  </system.diagnostics>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+  </startup>
+  <userSettings>
+    <DWSIM.My.MySettings>
+      <setting name="UserUnits" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="ShowTips" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="BackupFolder" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="BackupActivated" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="BackupInterval" serializeAs="String">
+        <value>5</value>
+      </setting>
+      <setting name="CultureInfo" serializeAs="String">
+        <value>en</value>
+      </setting>
+      <setting name="ChemSepDatabasePath" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="ReplaceComps" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="RedirectOutput" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="CheckForUpdates" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="UpgradeRequired" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="EnableParallelProcessing" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="MaxDegreeOfParallelism" serializeAs="String">
+        <value>-1</value>
+      </setting>
+      <setting name="EnableGPUProcessing" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="SelectedGPU" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="CudafyTarget" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="CudafyDeviceID" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="ShowCoolPropWarning" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="SolverMode" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="ServiceBusConnectionString" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="DebugLevel" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="ServerIPAddress" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="ServerPort" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="SolverTimeoutSeconds" serializeAs="String">
+        <value>360</value>
+      </setting>
+      <setting name="SolverBreakOnException" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="StorePreviousSolutions" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ShowWhatsNew" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="SaveBackupFile" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="MaxThreadMultiplier" serializeAs="String">
+        <value>8</value>
+      </setting>
+      <setting name="TaskScheduler" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="UseSIMDExtensions" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ShowSimulationToolStrip" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="ShowFlowsheetToolStrip" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="ShowUnitsToolStrip" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="ClipboardCopyMode_Compounds" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="ClipboardCopyMode_PropertyPackages" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="UndoRedo_RecalculateFlowsheet" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="MostRecentFiles" serializeAs="Xml">
+        <value>
+          <ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+        </value>
+      </setting>
+      <setting name="ObjectSelectorSplitterDistance1" serializeAs="String">
+        <value>351</value>
+      </setting>
+      <setting name="ObjectSelectorSplitterDistance2" serializeAs="String">
+        <value>86</value>
+      </setting>
+      <setting name="ObjectSelectorSplitterDistance3" serializeAs="String">
+        <value>84</value>
+      </setting>
+      <setting name="CloseFormsOnDeselecting" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="DefaultEditorLocation" serializeAs="String">
+        <value>8</value>
+      </setting>
+      <setting name="AutomaticUpdates" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="EnableMultipleObjectEditors" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="SimulationUpgradeWarning" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="HideSolidPhase_CO" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="IgnoreCompoundPropertiesOnLoad" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="OctavePath" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="OctaveProcessTimeout" serializeAs="String">
+        <value>15</value>
+      </setting>
+      <setting name="CurrentPlatform" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="CurrentEnvironment" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="PythonPath" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="PythonProcessTimeout" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="InspectorEnabled" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="ObjectEditor" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="DisplayPFDTip" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="FlowsheetRenderer" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="FlowsheetAntiAliasing" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="DoubleClickToEdit" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="SendCrashAndUsageAnalytics" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="UserEmail" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="ShowDataCollectionForm" serializeAs="String">
+        <value>True</value>
+      </setting>
+    </DWSIM.My.MySettings>
+  </userSettings>
+  <applicationSettings>
+    <DWSIM.My.MySettings>
+      <setting name="PreviewVersion" serializeAs="String">
+        <value />
+      </setting>
+      <setting name="Key1" serializeAs="String">
+        <value>51d86903-c99d-4710-a7f0-a38a447e436a</value>
+      </setting>
+      <setting name="Key2" serializeAs="String">
+        <value>c9c40f22-ee70-44bb-8654-b177db105878
 </value>
-            </setting>
-            <setting name="Key3" serializeAs="String">
-                <value>8a912ddd-956c-43d9-86bc-e372d90b3ae8</value>
-            </setting>
-        </DWSIM.My.MySettings>
-    </applicationSettings>
+      </setting>
+      <setting name="Key3" serializeAs="String">
+        <value>8a912ddd-956c-43d9-86bc-e372d90b3ae8</value>
+      </setting>
+    </DWSIM.My.MySettings>
+  </applicationSettings>
   <runtime>
     <loadFromRemoteSources enabled="true" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -291,5 +294,18 @@
   </runtime>
   <appSettings>
     <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -83,4 +83,3 @@ DWSIM.UI.Desktop.WPF|Cross-Platform UI Windows Presentation Foundation (WPF) Pla
 
 - DWSIM can be compiled using Visual Studio 2017 or newer on Windows.
 - To compile everything and run, select 'DWSIM' or 'DWSIM.UI.Desktop' as the startup project, change the Build target to 'Debug/x64', 'ReleaseLinux/x64', 'ReleaseWinMac/x64' or 'ReleaseWinMac/x86'.
-- On Windows, before running the compiled project, copy the contents of 'PlatformFiles/Common' and 'PlatformFiles/Windows' or 'PlatformFiles/Windows32' to the build output directory ('DWSIM/bin/x64/Debug', 'DWSIM/bin/x64/Release', 'DWSIM.UI.Desktop/bin/x64/Debug' or 'DWSIM.UI.Desktop/bin/x64/Release')


### PR DESCRIPTION
Very small change to the post-build events; just involves xcopy commands such that one leviates the need to copy the files for each build target. 