### PR TITLE
Output Energy stream - Conversion Reactor

### DIFF
--- a/DWSIM.Drawing.SkiaSharp/GraphicObjects/Shapes/ConversionReactor.vb
+++ b/DWSIM.Drawing.SkiaSharp/GraphicObjects/Shapes/ConversionReactor.vb
@@ -54,6 +54,7 @@ Namespace GraphicObjects.Shapes
             Dim myIC2 As New ConnectionPoint
             myIC2.Position = New Point(X + 0.125 * Width, Y + 0.7 * Height)
             myIC2.Type = ConType.ConEn
+            myIC2.Direction = ConDir.Up
 
             Dim myOC1 As New ConnectionPoint
             myOC1.Position = New Point(X + 0.5 * Width, Y)
@@ -63,18 +64,23 @@ Namespace GraphicObjects.Shapes
             myOC2.Position = New Point(X + 0.5 * Width, Y + Height)
             myOC2.Type = ConType.ConOut
 
+            Dim myOC3 As New ConnectionPoint
+            myOC3.Position = New Point(X + 0.625 * Width, Y + 0.7 * Height)
+            myOC3.Type = ConType.ConEn
+            myOC3.Direction = ConDir.Down
+
             With InputConnectors
 
                 If .Count <> 0 Then
                     .Item(0).Position = New Point(X + (0.25 - 0.14) * Width, Y + 0.5 * Height)
-                    .Item(1).Position = New Point(X + (0.25 - 0.14) * Width, Y + 0.7 * Height)
+                    .Item(1).Position = New Point(X + 0.25 * Width, Y + Height)
                 Else
                     .Add(myIC1)
                     .Add(myIC2)
                 End If
 
                 .Item(0).ConnectorName = "Inlet"
-                .Item(1).ConnectorName = "Energy Stream"
+                .Item(1).ConnectorName = "Energy Stream" 'only legacy. not in use anymore.
 
             End With
 
@@ -83,13 +89,16 @@ Namespace GraphicObjects.Shapes
                 If .Count <> 0 Then
                     .Item(0).Position = New Point(X + (0.75 + 0.14) * Width, Y + (0.1 + 0.14 / 2) * Height)
                     .Item(1).Position = New Point(X + (0.75 + 0.14) * Width, Y + (0.9 - 0.14 / 2) * Height)
+                    .Item(2).Position = New Point(X + 0.75 * Width, Y + Height)
                 Else
                     .Add(myOC1)
                     .Add(myOC2)
+                    .Add(myOC3)
                 End If
 
                 .Item(0).ConnectorName = "Vapor Outlet"
                 .Item(1).ConnectorName = "Liquid Outlet"
+                .Item(2).ConnectorName = "Energy Stream"
 
             End With
 

--- a/DWSIM.Drawing.SkiaSharp/GraphicsSurface/DesignSurface.vb
+++ b/DWSIM.Drawing.SkiaSharp/GraphicsSurface/DesignSurface.vb
@@ -1092,14 +1092,15 @@ Public Class GraphicsSurface
                         Select Case gObjFrom.ObjectType
                             Case ObjectType.Cooler, ObjectType.Heater, ObjectType.Pipe, ObjectType.Expander, ObjectType.ShortcutColumn, ObjectType.DistillationColumn, ObjectType.AbsorptionColumn,
                             ObjectType.ReboiledAbsorber, ObjectType.RefluxedAbsorber, ObjectType.OT_EnergyRecycle, ObjectType.ComponentSeparator, ObjectType.SolidSeparator,
-                            ObjectType.Filter, ObjectType.CustomUO, ObjectType.CapeOpenUO, ObjectType.FlowsheetUO, ObjectType.External
+                            ObjectType.Filter, ObjectType.CustomUO, ObjectType.CapeOpenUO, ObjectType.FlowsheetUO, ObjectType.External, ObjectType.RCT_Conversion
                                 GoTo 100
                             Case Else
                                 Throw New Exception("This connection is not allowed.")
                         End Select
 100:                    If gObjFrom.ObjectType <> ObjectType.CapeOpenUO And gObjFrom.ObjectType <> ObjectType.CustomUO And gObjFrom.ObjectType <> ObjectType.DistillationColumn _
                         And gObjFrom.ObjectType <> ObjectType.AbsorptionColumn And gObjFrom.ObjectType <> ObjectType.OT_EnergyRecycle And gObjFrom.ObjectType <> ObjectType.External _
-                                                    And gObjFrom.ObjectType <> ObjectType.RefluxedAbsorber And gObjFrom.ObjectType <> ObjectType.ReboiledAbsorber Then
+                                                    And gObjFrom.ObjectType <> ObjectType.RefluxedAbsorber And gObjFrom.ObjectType <> ObjectType.ReboiledAbsorber _
+                                                    And gObjFrom.ObjectType <> ObjectType.RCT_Conversion Then
                             If Not gObjFrom.EnergyConnector.IsAttached Then
                                 StartPos.X = gObjFrom.EnergyConnector.Position.X
                                 StartPos.Y = gObjFrom.EnergyConnector.Position.Y

--- a/DWSIM.UnitOperations/Reactors/Conversion.vb
+++ b/DWSIM.UnitOperations/Reactors/Conversion.vb
@@ -72,7 +72,9 @@ Namespace Reactors
                 Throw New Exception(FlowSheet.GetTranslatedString("Nohcorrentedematriac15"))
             ElseIf Not Me.GraphicObject.OutputConnectors(1).IsAttached Then
                 Throw New Exception(FlowSheet.GetTranslatedString("Nohcorrentedematriac15"))
-            ElseIf Not Me.GraphicObject.InputConnectors(1).IsAttached Then
+                'ElseIf Not Me.GraphicObject.InputConnectors(1).IsAttached Then
+                '    Throw New Exception(FlowSheet.GetTranslatedString("Nohcorrentedeenerg17"))
+            ElseIf Not Me.GraphicObject.OutputConnectors(2).IsAttached Then
                 Throw New Exception(FlowSheet.GetTranslatedString("Nohcorrentedeenerg17"))
             End If
 
@@ -670,8 +672,8 @@ Namespace Reactors
             End If
 
             'energy stream - update energy flow value (kW)
-            With GetInletEnergyStream(1)
-                .EnergyFlow = Me.DeltaQ.GetValueOrDefault
+            With GetOutletEnergyStream(2)
+                .EnergyFlow = -Me.DeltaQ.GetValueOrDefault
                 .GraphicObject.Calculated = True
             End With
 
@@ -681,11 +683,6 @@ Namespace Reactors
 
         Public Overrides Sub DeCalculate()
 
-            'If Not Me.GraphicObject.InputConnectors(0).IsAttached Then Throw New Exception(Flowsheet.GetTranslatedString("Nohcorrentedematriac10"))
-            'If Not Me.GraphicObject.OutputConnectors(0).IsAttached Then Throw New Exception(Flowsheet.GetTranslatedString("Nohcorrentedematriac11"))
-            'If Not Me.GraphicObject.OutputConnectors(1).IsAttached Then Throw New Exception(Flowsheet.GetTranslatedString("Nohcorrentedematriac11"))
-            'Dim ems As DWSIM.SimulationObjects.Streams.MaterialStream = form.SimulationObjects(Me.GraphicObject.InputConnectors(0).AttachedConnector.AttachedFrom.Name)
-            'Dim W As Double = ems.Phases(0).Properties.massflow.GetValueOrDefault
             Dim j As Integer = 0
 
             Dim ms As MaterialStream


### PR DESCRIPTION
Initially changed the Energy stream of Conversion Reactor from Input stream to Output stream.
Later commits for other reactors are still outstanding.

This allows to pass energy to other unit operations like a heater.