### PR TITLE
Use Q_{max,hot}/Q_{max,cold} instead of Q_{hot}/Q_{cold} in heat exchanger inspector

### DIFF
--- a/DWSIM.UnitOperations/UnitOperations/HeatExchanger.vb
+++ b/DWSIM.UnitOperations/UnitOperations/HeatExchanger.vb
@@ -1314,7 +1314,7 @@ Namespace UnitOperations
             HHx = tmpstr.Phases(0).Properties.enthalpy.GetValueOrDefault
             DeltaHh = Wh * (Hh1 - HHx) 'kW
 
-            IObj?.Paragraphs.Add("<mi>Q_{hot}</mi> = " & DeltaHh & " kW")
+            IObj?.Paragraphs.Add("<mi>Q_{max,hot}</mi> = " & DeltaHh & " kW")
 
             If DebugMode Then AppendDebugLine(String.Format("Doing a PT flash to calculate cold stream outlet enthalpy... P = {0} Pa, T = {1} K", Pc2, Th1))
             tmpstr = StInCold.Clone
@@ -1330,7 +1330,7 @@ Namespace UnitOperations
             HHx = tmpstr.Phases(0).Properties.enthalpy.GetValueOrDefault
             DeltaHc = Wc * (HHx - Hc1) 'kW
 
-            IObj?.Paragraphs.Add("<mi>Q_{cold}</mi> = " & DeltaHc & " kW")
+            IObj?.Paragraphs.Add("<mi>Q_{max,cold}</mi> = " & DeltaHc & " kW")
 
             MaxHeatExchange = Min(DeltaHc, DeltaHh) 'kW
 


### PR DESCRIPTION
In the inspector of the heat exchanger both `Q_{max,hot}`/`Q_{max,cold}` and `Q_{hot}`/`Q_{cold}` are used.
I guess the latter is a mistake for the former.

The following is an example screenshot:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/157688/160094519-915f6faa-b129-4364-b930-83a56b84e10a.png">
