### PR TITLE
Fix the Q_{max,cold} definition in the inspector of heat exchanger

### DIFF
--- a/DWSIM.UnitOperations/UnitOperations/HeatExchanger.vb
+++ b/DWSIM.UnitOperations/UnitOperations/HeatExchanger.vb
@@ -1284,7 +1284,7 @@ Namespace UnitOperations
             IObj?.Paragraphs.Add("The maximum theoretical heat exchange is calculated as the smallest value from")
 
             IObj?.Paragraphs.Add("<m>Q_{max,hot}=W_{hot}(H_{hot,in}-H_{hot,c})</m>")
-            IObj?.Paragraphs.Add("<m>Q_{max,cold}=W_{cold}(H_{cold,in}-H_{cold,h})</m>")
+            IObj?.Paragraphs.Add("<m>Q_{max,cold}=W_{cold}(H_{cold,h}-H_{cold,in})</m>")
 
             IObj?.Paragraphs.Add("where")
             IObj?.Paragraphs.Add("<mi>H_{hot,in}</mi> is the hot stream inlet enthalpy")


### PR DESCRIPTION
Currently `Q_{max,cold}` is defined as:

https://github.com/DanWBR/dwsim/blob/af579413bd45d740e0ac8050ccdbc05d1c2e6297/DWSIM.UnitOperations/UnitOperations/HeatExchanger.vb#L1286-L1287

But it seems that the following code actually computes `<m>Q_{max,cold}=W_{cold}(H_{cold,h} - H_{cold,in})</m>` (Here I assume that `Q_{cold}` is a mistake for `Q_{max,cold}` as I write in #305):

https://github.com/DanWBR/dwsim/blob/af579413bd45d740e0ac8050ccdbc05d1c2e6297/DWSIM.UnitOperations/UnitOperations/HeatExchanger.vb#L1319-L1333

I think the code is correct so I modified the formula to match the code.