### PR TITLE
Change text representation of {Heater,Cooler}.CalculationMode.OutletVaporFraction

### DIFF
--- a/DWSIM.UI.Desktop.Shared/Strings/StringArrays.cs
+++ b/DWSIM.UI.Desktop.Shared/Strings/StringArrays.cs
@@ -66,7 +66,7 @@ namespace DWSIM.UI.Desktop.Shared
         }
         public static String[] heatercalcmode()
         {
-            return new String[] { "Heat Added/Removed", "Outlet Temperature", "Outlet Quality", "Energy Stream" };
+            return new String[] { "Heat Added/Removed", "Outlet Temperature", "Outlet Vapor Fraction", "Energy Stream" };
         }
         public static String[] comprcalcmode()
         {


### PR DESCRIPTION
From the following explanation of the "Outlet Vapor Fraction" property of `Cooler` and `Heater`, I guess that the intended label for the `OutletVaporFraction` calculation mode is not "Outlet Quality" but "Outlet Vapor Fraction".

> If you chose 'Outlet Vapor Fraction' as the calculation mode, enter the desired value. If you chose a different calculation mode, this parameter will be calculated.

https://github.com/DanWBR/dwsim/blob/bc78ab2f974a96705fe239bc7431b2d497c35293/DWSIM.UnitOperations/UnitOperations/Cooler.vb#L1026-L1042

https://github.com/DanWBR/dwsim/blob/bc78ab2f974a96705fe239bc7431b2d497c35293/DWSIM.UnitOperations/UnitOperations/Heater.vb#L1031-L1047

The string table is looked up from following sites:

https://github.com/DanWBR/dwsim/blob/bc78ab2f974a96705fe239bc7431b2d497c35293/DWSIM.UI.Desktop.Editors/UnitOperations/General.cs#L656-L674

https://github.com/DanWBR/dwsim/blob/bc78ab2f974a96705fe239bc7431b2d497c35293/DWSIM.UI.Desktop.Editors/UnitOperations/General.cs#L542-L560


