### PR TITLE
fix the label of valve's DeltaP calculation parameter

### DIFF
--- a/DWSIM.UnitOperations/UnitOperations/Valve.vb
+++ b/DWSIM.UnitOperations/UnitOperations/Valve.vb
@@ -1227,7 +1227,7 @@ Namespace UnitOperations
             Select Case CalcMode
                 Case CalculationMode.DeltaP
                     list.Add(New Tuple(Of ReportItemType, String())(ReportItemType.TripleColumn,
-                            New String() {"Pressure Increase",
+                            New String() {"Pressure Drop",
                             Me.DeltaP.GetValueOrDefault.ConvertFromSI(su.deltaP).ToString(nf),
                             su.deltaP}))
                 Case CalculationMode.OutletPressure


### PR DESCRIPTION
In the `DeltaP` calculation mode of valves, the `DeltaP` calculation parameter is labeled as `Pressure Increase` but I think it should be `Pressure Drop`.

In other calculation modes, `DeltaP` (in those cases it is computed value instead of calculation parameter) is labeled as `Pressure Drop`.

https://github.com/DanWBR/dwsim/blob/7d810d9961266075cf513467a25161782021104d/DWSIM.UnitOperations/UnitOperations/Valve.vb#L1254-L1257