### PR TITLE
fix broken accents to use normal letters

### DIFF
--- a/DWSIM/Forms/DataRegression/FormDataRegression.Designer.vb
+++ b/DWSIM/Forms/DataRegression/FormDataRegression.Designer.vb
@@ -128,7 +128,7 @@ Partial Class FormDataRegression
         Me.tbParam = New System.Windows.Forms.TextBox()
         Me.Button4 = New System.Windows.Forms.Button()
         Me.MenuStrip1 = New System.Windows.Forms.MenuStrip()
-        Me.ParâmetrosDeInteraçãoToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.ParametrosDeInteracaoToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.SalvarEmBancoDeDadosXMLToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.TabControl1 = New System.Windows.Forms.TabControl()
         Me.TabPage1 = New System.Windows.Forms.TabPage()
@@ -841,17 +841,17 @@ Partial Class FormDataRegression
         '
         'MenuStrip1
         '
-        Me.MenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ParâmetrosDeInteraçãoToolStripMenuItem})
+        Me.MenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ParametrosDeInteracaoToolStripMenuItem})
         resources.ApplyResources(Me.MenuStrip1, "MenuStrip1")
         Me.MenuStrip1.Name = "MenuStrip1"
         '
-        'ParâmetrosDeInteraçãoToolStripMenuItem
+        'ParametrosDeInteracaoToolStripMenuItem
         '
-        Me.ParâmetrosDeInteraçãoToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SalvarEmBancoDeDadosXMLToolStripMenuItem})
-        Me.ParâmetrosDeInteraçãoToolStripMenuItem.MergeAction = System.Windows.Forms.MergeAction.Insert
-        Me.ParâmetrosDeInteraçãoToolStripMenuItem.MergeIndex = 2
-        Me.ParâmetrosDeInteraçãoToolStripMenuItem.Name = "ParâmetrosDeInteraçãoToolStripMenuItem"
-        resources.ApplyResources(Me.ParâmetrosDeInteraçãoToolStripMenuItem, "ParâmetrosDeInteraçãoToolStripMenuItem")
+        Me.ParametrosDeInteracaoToolStripMenuItem.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.SalvarEmBancoDeDadosXMLToolStripMenuItem})
+        Me.ParametrosDeInteracaoToolStripMenuItem.MergeAction = System.Windows.Forms.MergeAction.Insert
+        Me.ParametrosDeInteracaoToolStripMenuItem.MergeIndex = 2
+        Me.ParametrosDeInteracaoToolStripMenuItem.Name = "ParametrosDeInteracaoToolStripMenuItem"
+        resources.ApplyResources(Me.ParametrosDeInteracaoToolStripMenuItem, "ParametrosDeInteracaoToolStripMenuItem")
         '
         'SalvarEmBancoDeDadosXMLToolStripMenuItem
         '
@@ -1029,7 +1029,7 @@ Partial Class FormDataRegression
     Friend WithEvents GroupBox3 As System.Windows.Forms.GroupBox
     Friend WithEvents tbParam As System.Windows.Forms.TextBox
     Friend WithEvents MenuStrip1 As System.Windows.Forms.MenuStrip
-    Friend WithEvents ParâmetrosDeInteraçãoToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
+    Friend WithEvents ParametrosDeInteracaoToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents SalvarEmBancoDeDadosXMLToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents btnTransfere As System.Windows.Forms.Button
     Friend WithEvents TabControl1 As TabControl

--- a/DWSIM/Forms/Flowsheet/FormFlowsheet.vb
+++ b/DWSIM/Forms/Flowsheet/FormFlowsheet.vb
@@ -1464,7 +1464,7 @@ Public Class FormFlowsheet
         Me.FormSurface.Invalidate()
     End Sub
 
-    Private Sub AssistenteDeCriacaoDeSubstânciasToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CompoundCreatorWizardTSMI.Click
+    Private Sub AssistenteDeCriacaoDeSubstanciasToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CompoundCreatorWizardTSMI.Click
 
         RaiseEvent ToolOpened("Compound Creator Wizard", New EventArgs())
 

--- a/DWSIM/Forms/FlowsheetComponents/FlowsheetSurfaceSkiaSharp/FlowsheetSurface_SkiaSharp.vb
+++ b/DWSIM/Forms/FlowsheetComponents/FlowsheetSurfaceSkiaSharp/FlowsheetSurface_SkiaSharp.vb
@@ -3706,7 +3706,7 @@ Public Class FlowsheetSurface_SkiaSharp
 
     End Sub
 
-    Private Sub EditarAparênciaToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles EditAppearanceToolStripMenuItem.Click
+    Private Sub EditarAparenciaToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles EditAppearanceToolStripMenuItem.Click
 
         Flowsheet.RegisterSnapshot(SnapshotType.ObjectLayout)
 

--- a/DWSIM/Forms/FlowsheetComponents/LogPanel.Designer.vb
+++ b/DWSIM/Forms/FlowsheetComponents/LogPanel.Designer.vb
@@ -33,7 +33,7 @@ Partial Class LogPanel
         Me.Info = New System.Windows.Forms.DataGridViewButtonColumn()
         Me.ContextMenuStrip1 = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.LimparListaToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
-        Me.CopiarInformaçõesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
+        Me.CopiarInformacoesToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.dckMenu = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.FloatToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
         Me.DockLeftToolStripMenuItem = New System.Windows.Forms.ToolStripMenuItem()
@@ -138,7 +138,7 @@ Partial Class LogPanel
         '
         'ContextMenuStrip1
         '
-        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LimparListaToolStripMenuItem, Me.CopiarInformaçõesToolStripMenuItem})
+        Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.LimparListaToolStripMenuItem, Me.CopiarInformacoesToolStripMenuItem})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
         resources.ApplyResources(Me.ContextMenuStrip1, "ContextMenuStrip1")
         '
@@ -148,11 +148,11 @@ Partial Class LogPanel
         Me.LimparListaToolStripMenuItem.Name = "LimparListaToolStripMenuItem"
         resources.ApplyResources(Me.LimparListaToolStripMenuItem, "LimparListaToolStripMenuItem")
         '
-        'CopiarInformaçõesToolStripMenuItem
+        'CopiarInformacoesToolStripMenuItem
         '
-        Me.CopiarInformaçõesToolStripMenuItem.Image = Global.DWSIM.My.Resources.Resources.copy
-        Me.CopiarInformaçõesToolStripMenuItem.Name = "CopiarInformaçõesToolStripMenuItem"
-        resources.ApplyResources(Me.CopiarInformaçõesToolStripMenuItem, "CopiarInformaçõesToolStripMenuItem")
+        Me.CopiarInformacoesToolStripMenuItem.Image = Global.DWSIM.My.Resources.Resources.copy
+        Me.CopiarInformacoesToolStripMenuItem.Name = "CopiarInformacoesToolStripMenuItem"
+        resources.ApplyResources(Me.CopiarInformacoesToolStripMenuItem, "CopiarInformacoesToolStripMenuItem")
         '
         'dckMenu
         '
@@ -245,5 +245,5 @@ Partial Class LogPanel
     Friend WithEvents Tipo As DataGridViewTextBoxColumn
     Friend WithEvents Mensagem As DataGridViewTextBoxColumn
     Friend WithEvents Info As DataGridViewButtonColumn
-    Friend WithEvents CopiarInformaçõesToolStripMenuItem As ToolStripMenuItem
+    Friend WithEvents CopiarInformacoesToolStripMenuItem As ToolStripMenuItem
 End Class

--- a/DWSIM/Forms/FlowsheetComponents/LogPanel.vb
+++ b/DWSIM/Forms/FlowsheetComponents/LogPanel.vb
@@ -101,7 +101,7 @@ Public Class LogPanel
 
     End Sub
 
-    Private Sub CopiarInformaçõesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopiarInformaçõesToolStripMenuItem.Click
+    Private Sub CopiarInformacoesToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles CopiarInformacoesToolStripMenuItem.Click
 
         If Grid1.SelectedRows.Count > 0 Then
 


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/71d1eb98-a9ce-4436-83f0-9efb646b723a)


Yes, you can use accent letters, but the file needs to be in the correct encoding.
I tested it on 3 different pc's and every single VS2022 instance chose an encoding which broke these characters.